### PR TITLE
Pull request to fix 'Makefile:127: recipe for target 'all' failed'

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Cmake and a c++ compiler are required for building.
 ```bash
 git submodule init
 git submodule update
+mkdir build
 cd build
 cmake ../
 cmake --build . -- -j 6

--- a/src/aggregationinfo.cpp
+++ b/src/aggregationinfo.cpp
@@ -286,7 +286,7 @@ void AggregationInfo::SortIntoVectors(std::vector<uint8_t*> &ms,
 // Simple merging, no exponentiation is performed
 AggregationInfo AggregationInfo::SimpleMergeInfos(
         std::vector<AggregationInfo> const &infos) {
-    std::set<const BLSPublicKey> pubKeysDedup;
+    std::set<BLSPublicKey> pubKeysDedup;
 
     AggregationTree newTree;
     for (const AggregationInfo &info : infos) {


### PR DESCRIPTION
Using Ubuntu 16.04, I encountered an error while building the library:
`Makefile:127: recipe for target 'all' failed`

The fix is to remove 'const' from line 289 in  src/aggregationinfo.cpp:
`std::set<const BLSPublicKey> pubKeysDedup;`

In addition, I added 'mkdir build' to README.md to complete the build instructions.