### PR TITLE
Use malloc instead of dynamic allocation on-stack in pairing functions

### DIFF
--- a/contrib/relic/src/pp/relic_pp_map.c
+++ b/contrib/relic/src/pp/relic_pp_map.c
@@ -49,10 +49,12 @@
  */
 static void pp_mil_k2(fp2_t r, ep_t *t, ep_t *p, ep_t *q, int m, bn_t a) {
 	fp2_t l;
-	ep_t _q[m];
+	ep_t *_q;
 	int i, j;
 
 	fp2_null(l);
+
+	_q = malloc(sizeof(ep_t) * m);
 
 	TRY {
 		fp2_new(l);
@@ -85,6 +87,7 @@ static void pp_mil_k2(fp2_t r, ep_t *t, ep_t *p, ep_t *q, int m, bn_t a) {
 		for (j = 0; j < m; j++) {
 			ep_free(_q[j]);
 		}
+		free(_q);
 	}
 }
 
@@ -100,11 +103,13 @@ static void pp_mil_k2(fp2_t r, ep_t *t, ep_t *p, ep_t *q, int m, bn_t a) {
  */
 static void pp_mil_lit_k2(fp2_t r, ep_t *t, ep_t *p, ep_t *q, int m, bn_t a) {
 	fp2_t l, _l;
-	ep_t _q[m];
+	ep_t *_q;
 	int i, j;
 
 	fp2_null(l);
 	fp2_null(_l);
+
+	_q = malloc(sizeof(ep_t) * m);
 
 	TRY {
 		fp2_new(l);
@@ -141,6 +146,7 @@ static void pp_mil_lit_k2(fp2_t r, ep_t *t, ep_t *p, ep_t *q, int m, bn_t a) {
 		for (j = 0; j < m; j++) {
 			ep_null(_q[j]);
 		}
+		free(_q);
 	}
 }
 
@@ -157,7 +163,7 @@ static void pp_mil_lit_k2(fp2_t r, ep_t *t, ep_t *p, ep_t *q, int m, bn_t a) {
  */
 static void pp_mil_k12(fp12_t r, ep2_t *t, ep2_t *q, ep_t *p, int m, bn_t a) {
 	fp12_t l;
-	ep_t _p[m];
+	ep_t *_p;
 	int i, j;
 
 	if (m == 0) {
@@ -165,6 +171,8 @@ static void pp_mil_k12(fp12_t r, ep2_t *t, ep2_t *q, ep_t *p, int m, bn_t a) {
 	}
 
 	fp12_null(l);
+
+	_p = malloc(sizeof(ep_t) * m);
 
 	TRY {
 		fp12_new(l);
@@ -213,6 +221,7 @@ static void pp_mil_k12(fp12_t r, ep2_t *t, ep2_t *q, ep_t *p, int m, bn_t a) {
 		for (j = 0; j < m; j++) {
 			ep_free(_p[j]);
 		}
+		free(_p);
 	}
 }
 
@@ -231,8 +240,8 @@ static void pp_mil_k12(fp12_t r, ep2_t *t, ep2_t *q, ep_t *p, int m, bn_t a) {
 static void pp_mil_sps_k12(fp12_t r, ep2_t *t, ep2_t *q, ep_t *p, int m, int *s,
 		int len) {
 	fp12_t l;
-	ep_t _p[m];
-	ep2_t _q[m];
+	ep_t *_p;
+	ep2_t *_q;
 	int i, j;
 
 	if (m == 0) {
@@ -240,6 +249,9 @@ static void pp_mil_sps_k12(fp12_t r, ep2_t *t, ep2_t *q, ep_t *p, int m, int *s,
 	}
 
 	fp12_null(l);
+
+	_p = malloc(sizeof(ep_t) * m);
+	_q = malloc(sizeof(ep2_t) * m);
 
 	TRY {
 		fp12_new(l);
@@ -304,6 +316,8 @@ static void pp_mil_sps_k12(fp12_t r, ep2_t *t, ep2_t *q, ep_t *p, int m, int *s,
 			ep_free(_p[j]);
 			ep2_free(_q[j]);
 		}
+		free(_p);
+		free(_q);
 	}
 }
 
@@ -320,10 +334,12 @@ static void pp_mil_sps_k12(fp12_t r, ep2_t *t, ep2_t *q, ep_t *p, int m, int *s,
  */
 static void pp_mil_lit_k12(fp12_t r, ep_t *t, ep_t *p, ep2_t *q, int m, bn_t a) {
 	fp12_t l;
-	ep2_t _q[m];
+	ep2_t *_q;
 	int j;
 
 	fp12_null(l);
+
+	_q = malloc(sizeof(ep2_t) * m);
 
 	TRY {
 		fp12_new(l);
@@ -355,6 +371,7 @@ static void pp_mil_lit_k12(fp12_t r, ep_t *t, ep_t *p, ep2_t *q, int m, bn_t a) 
 		for (j = 0; j < m; j++) {
 			ep2_free(_q[j]);
 		}
+		free(_q);
 	}
 }
 
@@ -453,11 +470,15 @@ void pp_map_tatep_k2(fp2_t r, ep_t p, ep_t q) {
 }
 
 void pp_map_sim_tatep_k2(fp2_t r, ep_t *p, ep_t *q, int m) {
-	ep_t _p[m], _q[m], t[m];
+	ep_t *_p, *_q, *t;
 	bn_t n;
 	int i, j;
 
 	bn_null(n);
+
+	_p = malloc(sizeof(ep_t) * m);
+	_q = malloc(sizeof(ep_t) * m);
+	t = malloc(sizeof(ep_t) * m);
 
 	TRY {
 		bn_new(n);
@@ -495,6 +516,9 @@ void pp_map_sim_tatep_k2(fp2_t r, ep_t *p, ep_t *q, int m) {
 			ep_free(_q[i]);
 			ep_free(t[i]);
 		}
+		free(_p);
+		free(_q);
+		free(t);
 	}
 }
 
@@ -540,12 +564,16 @@ void pp_map_tatep_k12(fp12_t r, ep_t p, ep2_t q) {
 }
 
 void pp_map_sim_tatep_k12(fp12_t r, ep_t *p, ep2_t *q, int m) {
-	ep_t _p[m], t[m];
-	ep2_t _q[m];
+	ep_t *_p, *t;
+	ep2_t *_q;
 	bn_t n;
 	int i, j;
 
 	bn_null(n);
+
+	_p = malloc(sizeof(ep_t) * m);
+	_q = malloc(sizeof(ep2_t) * m);
+	t = malloc(sizeof(ep_t) * m);
 
 	TRY {
 		bn_new(n);
@@ -583,6 +611,9 @@ void pp_map_sim_tatep_k12(fp12_t r, ep_t *p, ep2_t *q, int m) {
 			ep_free(t[i]);
 			ep2_free(_q[i]);
 		}
+		free(_p);
+		free(_q);
+		free(t);
 	}
 }
 
@@ -645,7 +676,7 @@ void pp_map_weilp_k2(fp2_t r, ep_t p, ep_t q) {
 }
 
 void pp_map_sim_weilp_k2(fp2_t r, ep_t *p, ep_t *q, int m) {
-	ep_t _p[m], _q[m], t0[m], t1[m];
+	ep_t *_p, *_q, *t0, *t1;
 	fp2_t r0, r1;
 	bn_t n;
 	int i, j;
@@ -653,6 +684,11 @@ void pp_map_sim_weilp_k2(fp2_t r, ep_t *p, ep_t *q, int m) {
 	fp2_null(r0);
 	fp2_null(r1);
 	bn_null(r);
+
+	_p = malloc(sizeof(ep_t) * m);
+	_q = malloc(sizeof(ep_t) * m);
+	t0 = malloc(sizeof(ep_t) * m);
+	t1 = malloc(sizeof(ep_t) * m);
 
 	TRY {
 		fp2_new(r0);
@@ -705,6 +741,10 @@ void pp_map_sim_weilp_k2(fp2_t r, ep_t *p, ep_t *q, int m) {
 			ep_free(t0[i]);
 			ep_free(t1[i]);
 		}
+		free(_p);
+		free(_q);
+		free(t0);
+		free(t1);
 	}
 }
 
@@ -763,8 +803,8 @@ void pp_map_weilp_k12(fp12_t r, ep_t p, ep2_t q) {
 }
 
 void pp_map_sim_weilp_k12(fp12_t r, ep_t *p, ep2_t *q, int m) {
-	ep_t _p[m], t0[m];
-	ep2_t _q[m], t1[m];
+	ep_t *_p, *t0;
+	ep2_t *_q, *t1;
 	fp12_t r0, r1;
 	bn_t n;
 	int i, j;
@@ -772,6 +812,11 @@ void pp_map_sim_weilp_k12(fp12_t r, ep_t *p, ep2_t *q, int m) {
 	fp12_null(r0);
 	fp12_null(r1);
 	bn_null(r);
+
+	_p = malloc(sizeof(ep_t) * m);
+	_q = malloc(sizeof(ep2_t) * m);
+	t0 = malloc(sizeof(ep_t) * m);
+	t1 = malloc(sizeof(ep2_t) * m);
 
 	TRY {
 		fp12_new(r0);
@@ -824,6 +869,10 @@ void pp_map_sim_weilp_k12(fp12_t r, ep_t *p, ep2_t *q, int m) {
 			ep2_free(_q[i]);
 			ep2_free(t1[i]);
 		}
+		free(_p);
+		free(_q);
+		free(t0);
+		free(t1);
 	}
 }
 
@@ -901,10 +950,14 @@ void pp_map_oatep_k12(fp12_t r, ep_t p, ep2_t q) {
 }
 
 void pp_map_sim_oatep_k12(fp12_t r, ep_t *p, ep2_t *q, int m) {
-	ep_t _p[m];
-	ep2_t t[m], _q[m];
+	ep_t *_p;
+	ep2_t *t, *_q;
 	bn_t a;
 	int i, j, len = FP_BITS, s[FP_BITS];
+
+	_p = malloc(sizeof(ep_t) * m);
+	_q = malloc(sizeof(ep2_t) * m);
+	t = malloc(sizeof(ep2_t) * m);
 
 	TRY {
 		bn_null(a);
@@ -976,6 +1029,9 @@ void pp_map_sim_oatep_k12(fp12_t r, ep_t *p, ep2_t *q, int m) {
 			ep2_free(_q[i]);
 			ep2_free(t[i]);
 		}
+		free(_p);
+		free(_q);
+		free(t);
 	}
 }
 


### PR DESCRIPTION
Description from commit:
```
When these are called with thousands of pairings, dynamic allocation on
the stack results in stack overflows, leading to crashes.

Better to use heap allocation here.
```

If this is merged into this repo, I'll also create a PR into the relic project.