### PR TITLE
Always include <gmp.h> before including relic headers

### DIFF
--- a/src/bls.hpp
+++ b/src/bls.hpp
@@ -18,6 +18,13 @@
 #include <vector>
 #include <map>
 #include <string>
+
+#include "relic_conf.h"
+
+#if defined GMP && ARITH == GMP
+#include <gmp.h>
+#endif
+
 #include "blspublickey.hpp"
 #include "blsprivatekey.hpp"
 #include "blssignature.hpp"

--- a/src/blsprivatekey.hpp
+++ b/src/blsprivatekey.hpp
@@ -15,6 +15,12 @@
 #ifndef SRC_BLSPRIVATEKEY_HPP_
 #define SRC_BLSPRIVATEKEY_HPP_
 
+#include "relic_conf.h"
+
+#if defined GMP && ARITH == GMP
+#include <gmp.h>
+#endif
+
 #include "blspublickey.hpp"
 #include "blssignature.hpp"
 

--- a/src/blspublickey.hpp
+++ b/src/blspublickey.hpp
@@ -18,6 +18,12 @@
 #include <iostream>
 #include <vector>
 
+#include "relic_conf.h"
+
+#if defined GMP && ARITH == GMP
+#include <gmp.h>
+#endif
+
 #include "blsutil.hpp"
 
 /** An encapsulated public key. */

--- a/src/blssignature.hpp
+++ b/src/blssignature.hpp
@@ -18,6 +18,12 @@
 #include <iostream>
 #include <vector>
 
+#include "relic_conf.h"
+
+#if defined GMP && ARITH == GMP
+#include <gmp.h>
+#endif
+
 #include "blsutil.hpp"
 #include "aggregationinfo.hpp"
 

--- a/src/blsutil.hpp
+++ b/src/blsutil.hpp
@@ -21,6 +21,12 @@
 #include <string>
 #include <cstdlib>
 
+#include "relic_conf.h"
+
+#if defined GMP && ARITH == GMP
+#include <gmp.h>
+#endif
+
 #if BLSALLOC == sodium
 namespace libsodium {
     #include "sodium/utils.h"

--- a/src/chaincode.hpp
+++ b/src/chaincode.hpp
@@ -17,6 +17,12 @@
 
 #include <iostream>
 
+#include "relic_conf.h"
+
+#if defined GMP && ARITH == GMP
+#include <gmp.h>
+#endif
+
 namespace relic {
     #include "relic.h"
     #include "relic_test.h"

--- a/src/extendedprivatekey.hpp
+++ b/src/extendedprivatekey.hpp
@@ -15,6 +15,12 @@
 #ifndef SRC_EXTENDEDPRIVATEKEY_HPP_
 #define SRC_EXTENDEDPRIVATEKEY_HPP_
 
+#include "relic_conf.h"
+
+#if defined GMP && ARITH == GMP
+#include <gmp.h>
+#endif
+
 #include "blsprivatekey.hpp"
 #include "blspublickey.hpp"
 #include "chaincode.hpp"

--- a/src/extendedpublickey.hpp
+++ b/src/extendedpublickey.hpp
@@ -15,6 +15,12 @@
 #ifndef SRC_EXTENDEDPUBLICKEY_HPP_
 #define SRC_EXTENDEDPUBLICKEY_HPP_
 
+#include "relic_conf.h"
+
+#if defined GMP && ARITH == GMP
+#include <gmp.h>
+#endif
+
 #include "blspublickey.hpp"
 #include "chaincode.hpp"
 


### PR DESCRIPTION
The relic headers internally include <gmp.h> as well. At the same time,
inclusion of relic headers is wrapped into a namespace, which makes the
gmp headers be part of that namespace as well. This leads to conflicting
definitions of "std::ostream& operator<< (std::ostream &, mpz_srcptr)" and
friends on Debian stretch (if gmp from /usr is used).