### PR TITLE
Avoid pre-compressing points and remove the need for operator<

### DIFF
--- a/contrib/relic/src/epx/relic_ep2_util.c
+++ b/contrib/relic/src/epx/relic_ep2_util.c
@@ -43,6 +43,7 @@ void ep2_set_infty(ep2_t p) {
 	fp2_zero(p->x);
 	fp2_zero(p->y);
 	fp2_zero(p->z);
+	p->norm = 1;
 }
 
 void ep2_copy(ep2_t r, ep2_t p) {

--- a/python-bindings/pythonbindings.cpp
+++ b/python-bindings/pythonbindings.cpp
@@ -82,7 +82,6 @@ PYBIND11_MODULE(blspy, m) {
             uint8_t* input = reinterpret_cast<uint8_t*>(&std::string(msg)[0]);
             return k.SignPrehashed(input);
         })
-        .def("size", &BLSPrivateKey::size)
         .def(py::self == py::self)
         .def(py::self != py::self)
         .def("__repr__", [](const BLSPrivateKey &k) {
@@ -110,10 +109,8 @@ PYBIND11_MODULE(blspy, m) {
             delete[] output;
             return ret;
         })
-        .def("size", &BLSPublicKey::size)
         .def(py::self == py::self)
         .def(py::self != py::self)
-        .def(py::self < py::self)
         .def("__repr__", [](const BLSPublicKey &pk) {
             std::stringstream s;
             s << pk;
@@ -141,10 +138,8 @@ PYBIND11_MODULE(blspy, m) {
         .def("get_aggregation_info", [](const BLSSignature &sig) {
             return *sig.GetAggregationInfo();
         })
-        .def("size", &BLSSignature::size)
         .def(py::self == py::self)
         .def(py::self != py::self)
-        .def(py::self < py::self)
         .def("__repr__", [](const BLSSignature &sig) {
             std::stringstream s;
             s << sig;

--- a/python-bindings/test.py
+++ b/python-bindings/test.py
@@ -106,12 +106,13 @@ def test2():
     assert(sk != sk2)
     assert(pk.get_fingerprint() == 0xddad59bb)
 
+    sk2_ser = sk2.serialize()
     pk2_ser = pk2.serialize()
     pk2_copy = BLSPublicKey.from_bytes(pk2_ser)
     assert(pk2 == pk2_copy)
     assert(pk != pk2)
-    assert(pk2.size() == 48)
-    assert(sk2.size() == 32)
+    assert(len(pk2_ser) == 48)
+    assert(len(sk2_ser) == 32)
 
     message = bytes("this is the message", "utf-8")
     sig = sk.sign(message)
@@ -123,7 +124,7 @@ def test2():
     assert(a1 == a2)
     sig2 = sk2.sign(message)
 
-    assert(sig.size() == 96)
+    assert(len(sig_ser) == 96)
     assert(sig != sig2)
     assert(sig == sig_cp)
 

--- a/src/aggregationinfo.cpp
+++ b/src/aggregationinfo.cpp
@@ -315,15 +315,18 @@ AggregationInfo AggregationInfo::SecureMergeInfos(
     });
 
     std::vector<uint8_t*> msgAndPks;
-    std::vector<std::vector<uint8_t>> serPks;
+    std::vector<uint8_t*> serPks;
     std::vector<size_t> sortedKeys;
     msgAndPks.reserve(pkCount);
     serPks.reserve(pkCount);
     sortedKeys.reserve(pkCount);
     for (size_t i = 0; i < sortedCollidingInfos.size(); i++) {
         for (auto &mapEntry : collidingInfosArg[sortedCollidingInfos[i]].tree) {
+            uint8_t *serPk = new uint8_t[BLSPublicKey::PUBLIC_KEY_SIZE];
+            memcpy(serPk, mapEntry.first + BLS::MESSAGE_HASH_LEN, BLSPublicKey::PUBLIC_KEY_SIZE);
+
             msgAndPks.emplace_back(mapEntry.first);
-            serPks.emplace_back(mapEntry.first + BLS::MESSAGE_HASH_LEN, mapEntry.first + BLS::MESSAGE_HASH_LEN + BLSPublicKey::PUBLIC_KEY_SIZE);
+            serPks.emplace_back(serPk);
             sortedKeys.emplace_back(sortedKeys.size());
         }
     }
@@ -378,6 +381,10 @@ AggregationInfo AggregationInfo::SecureMergeInfos(
     std::vector<BLSPublicKey> pks;
     std::vector<uint8_t*> messageHashes;
     SortIntoVectors(messageHashes, pks, newTree);
+
+    for (auto p : serPks) {
+        delete[] p;
+    }
 
     return AggregationInfo(newTree, messageHashes, pks);
 }

--- a/src/bls.cpp
+++ b/src/bls.cpp
@@ -592,7 +592,7 @@ bool BLS::VerifyNative(
 
 void BLS::HashPubKeys(relic::bn_t* output, size_t numOutputs,
                       std::vector<std::vector<uint8_t>> const &serPubKeys,
-                      std::vector<size_t> const& sorted) {
+                      std::vector<size_t> const& sortedIndices) {
     relic::bn_t order;
 
     bn_new(order);
@@ -602,7 +602,7 @@ void BLS::HashPubKeys(relic::bn_t* output, size_t numOutputs,
     pkBuffer.reserve(serPubKeys.size() * BLSPublicKey::PUBLIC_KEY_SIZE);
 
     for (size_t i = 0; i < serPubKeys.size(); i++) {
-        const uint8_t* p = serPubKeys[sorted[i]].data();
+        const uint8_t* p = serPubKeys[sortedIndices[i]].data();
         pkBuffer.insert(pkBuffer.end(), p, p + BLSPublicKey::PUBLIC_KEY_SIZE);
     }
 

--- a/src/bls.hpp
+++ b/src/bls.hpp
@@ -79,7 +79,7 @@ class BLS {
     static void HashPubKeys(
             relic::bn_t* output,
             size_t numOutputs,
-            std::vector<std::vector<uint8_t>> const &serPubKeys,
+            std::vector<uint8_t*> const &serPubKeys,
             std::vector<size_t> const &sortedIndices);
 
  private:

--- a/src/bls.hpp
+++ b/src/bls.hpp
@@ -79,10 +79,6 @@ class BLS {
     static void HashPubKeys(
             relic::bn_t* output,
             size_t numOutputs,
-            std::vector<BLSPublicKey> const &pubKeys);
-    static void HashPubKeys(
-            relic::bn_t* output,
-            size_t numOutputs,
             std::vector<std::vector<uint8_t>> const &serPubKeys,
             std::vector<size_t> const &sorted);
 

--- a/src/bls.hpp
+++ b/src/bls.hpp
@@ -80,7 +80,7 @@ class BLS {
             relic::bn_t* output,
             size_t numOutputs,
             std::vector<std::vector<uint8_t>> const &serPubKeys,
-            std::vector<size_t> const &sorted);
+            std::vector<size_t> const &sortedIndices);
 
  private:
     // Efficiently aggregates many signatures using the simple aggregation

--- a/src/bls.hpp
+++ b/src/bls.hpp
@@ -80,6 +80,11 @@ class BLS {
             relic::bn_t* output,
             size_t numOutputs,
             std::vector<BLSPublicKey> const &pubKeys);
+    static void HashPubKeys(
+            relic::bn_t* output,
+            size_t numOutputs,
+            std::vector<std::vector<uint8_t>> const &serPubKeys,
+            std::vector<size_t> const &sorted);
 
  private:
     // Efficiently aggregates many signatures using the simple aggregation

--- a/src/blsprivatekey.cpp
+++ b/src/blsprivatekey.cpp
@@ -105,23 +105,15 @@ BLSPrivateKey& BLSPrivateKey::operator=(const BLSPrivateKey &rhs) {
     return *this;
 }
 
-size_t BLSPrivateKey::size() const {
-    BLS::AssertInitialized();
-    return BLSPrivateKey::PRIVATE_KEY_SIZE;
-}
-
-uint8_t* BLSPrivateKey::begin() const {
-    BLS::AssertInitialized();
-    return reinterpret_cast<uint8_t*>((*keydata)->dp);
-}
-uint8_t* BLSPrivateKey::end() const {
-    BLS::AssertInitialized();
-    return reinterpret_cast<uint8_t*>((*keydata)->dp) + size();
-}
-
 void BLSPrivateKey::Serialize(uint8_t* buffer) const {
     BLS::AssertInitialized();
     bn_write_bin(buffer, BLSPrivateKey::PRIVATE_KEY_SIZE, *keydata);
+}
+
+std::vector<uint8_t> BLSPrivateKey::Serialize() const {
+    std::vector<uint8_t> data(PRIVATE_KEY_SIZE);
+    Serialize(data.data());
+    return data;
 }
 
 BLSSignature BLSPrivateKey::Sign(const uint8_t *msg, size_t len) const {

--- a/src/blsprivatekey.hpp
+++ b/src/blsprivatekey.hpp
@@ -52,15 +52,11 @@ class BLSPrivateKey {
     friend bool operator!=(const BLSPrivateKey& a, const BLSPrivateKey& b);
     BLSPrivateKey& operator=(const BLSPrivateKey& rhs);
 
-    // Simple read-only vector-like interface.
-    size_t size() const;
-    uint8_t* begin() const;
-    uint8_t* end() const;
-
     relic::bn_t* GetValue() const { return keydata; }
 
     // Serialize the key into bytes
     void Serialize(uint8_t* buffer) const;
+    std::vector<uint8_t> Serialize() const;
 
     // Sign a message
     BLSSignature Sign(const uint8_t *msg, size_t len) const;

--- a/src/blspublickey.cpp
+++ b/src/blspublickey.cpp
@@ -72,10 +72,6 @@ bool operator!=(BLSPublicKey const&a,  BLSPublicKey const&b) {
     return !(a == b);
 }
 
-bool operator<(BLSPublicKey const&a,  BLSPublicKey const&b) {
-    return std::memcmp(a.data, b.data, BLSPublicKey::PUBLIC_KEY_SIZE) < 0;
-}
-
 std::ostream &operator<<(std::ostream &os, BLSPublicKey const &pk) {
     BLS::AssertInitialized();
     return os << BLSUtil::HexStr(pk.data, BLSPublicKey::PUBLIC_KEY_SIZE);

--- a/src/blspublickey.cpp
+++ b/src/blspublickey.cpp
@@ -51,25 +51,15 @@ BLSPublicKey::BLSPublicKey(const BLSPublicKey &pubKey) {
     CompressPoint(data, &q);
 }
 
-size_t BLSPublicKey::size() const {
-    return PUBLIC_KEY_SIZE;
-}
-
-const uint8_t* BLSPublicKey::begin() const {
-    return data;
-}
-
-const uint8_t* BLSPublicKey::end() const {
-    return data + size();
-}
-
-const uint8_t& BLSPublicKey::operator[](size_t pos) const {
-    return data[pos];
-}
-
 void BLSPublicKey::Serialize(uint8_t *buffer) const {
     BLS::AssertInitialized();
     std::memcpy(buffer, data, PUBLIC_KEY_SIZE);
+}
+
+std::vector<uint8_t> BLSPublicKey::Serialize() const {
+    std::vector<uint8_t> data(PUBLIC_KEY_SIZE);
+    Serialize(data.data());
+    return data;
 }
 
 // Comparator implementation.

--- a/src/blspublickey.hpp
+++ b/src/blspublickey.hpp
@@ -60,7 +60,6 @@ class BLSPublicKey {
 
     // Public key group element
     relic::g1_t q;
-    uint8_t data[BLSPublicKey::PUBLIC_KEY_SIZE];
 };
 
 #endif  // SRC_BLSPUBLICKEY_HPP_

--- a/src/blspublickey.hpp
+++ b/src/blspublickey.hpp
@@ -43,7 +43,6 @@ class BLSPublicKey {
     // Comparator implementation.
     friend bool operator==(BLSPublicKey const &a,  BLSPublicKey const &b);
     friend bool operator!=(BLSPublicKey const &a,  BLSPublicKey const &b);
-    friend bool operator<(BLSPublicKey const &a,  BLSPublicKey const &b);
     friend std::ostream &operator<<(std::ostream &os, BLSPublicKey const &s);
 
     void Serialize(uint8_t *buffer) const;

--- a/src/blspublickey.hpp
+++ b/src/blspublickey.hpp
@@ -40,12 +40,6 @@ class BLSPublicKey {
     // Construct a public key from another public key.
     BLSPublicKey(const BLSPublicKey &pubKey);
 
-    // Simple read-only vector-like interface to the pubkey data.
-    size_t size() const;
-    const uint8_t* begin() const;
-    const uint8_t* end() const;
-    const uint8_t& operator[](size_t pos) const;
-
     // Comparator implementation.
     friend bool operator==(BLSPublicKey const &a,  BLSPublicKey const &b);
     friend bool operator!=(BLSPublicKey const &a,  BLSPublicKey const &b);
@@ -53,6 +47,7 @@ class BLSPublicKey {
     friend std::ostream &operator<<(std::ostream &os, BLSPublicKey const &s);
 
     void Serialize(uint8_t *buffer) const;
+    std::vector<uint8_t> Serialize() const;
     void GetPoint(relic::g1_t &output) const { *output = *q; }
 
     // Returns the first 4 bytes of the serialized pk

--- a/src/blssignature.cpp
+++ b/src/blssignature.cpp
@@ -160,10 +160,6 @@ bool operator!=(BLSSignature const &a, BLSSignature const &b) {
     return !(a == b);
 }
 
-bool operator<(BLSSignature const&a,  BLSSignature const&b) {
-    return std::memcmp(a.data, b.data, BLSSignature::SIGNATURE_SIZE) < 0;
-}
-
 std::ostream &operator<<(std::ostream &os, BLSSignature const &s) {
     BLS::AssertInitialized();
     return os << BLSUtil::HexStr(s.data, BLSSignature::SIGNATURE_SIZE);

--- a/src/blssignature.cpp
+++ b/src/blssignature.cpp
@@ -140,25 +140,15 @@ BLSSignature BLSSignature::DivideBy(std::vector<BLSSignature> const &divisorSigs
     return copy;
 }
 
-const uint8_t& BLSSignature::operator[](size_t pos) const {
-    return data[pos];
-}
-
-const uint8_t* BLSSignature::begin() const {
-    return data;
-}
-
-const uint8_t* BLSSignature::end() const {
-    return data + size();
-}
-
-size_t BLSSignature::size() const {
-    return BLSSignature::SIGNATURE_SIZE;
-}
-
 void BLSSignature::Serialize(uint8_t* buffer) const {
     BLS::AssertInitialized();
     std::memcpy(buffer, data, BLSSignature::SIGNATURE_SIZE);
+}
+
+std::vector<uint8_t> BLSSignature::Serialize() const {
+    std::vector<uint8_t> data(SIGNATURE_SIZE);
+    Serialize(data.data());
+    return data;
 }
 
 bool operator==(BLSSignature const &a, BLSSignature const &b) {

--- a/src/blssignature.hpp
+++ b/src/blssignature.hpp
@@ -66,14 +66,10 @@ class BLSSignature {
     // be verified.
     void SetAggregationInfo(const AggregationInfo &newAggregationInfo);
 
-    const uint8_t& operator[](size_t pos) const;
-    const uint8_t* begin() const;
-    const uint8_t* end() const;
-    size_t size() const;
-
     // Serializes ONLY the 96 byte public key. It does not serialize
     // the aggregation info.
     void Serialize(uint8_t* buffer) const;
+    std::vector<uint8_t> Serialize() const;
 
     friend bool operator==(BLSSignature const &a, BLSSignature const &b);
     friend bool operator!=(BLSSignature const &a, BLSSignature const &b);

--- a/src/blssignature.hpp
+++ b/src/blssignature.hpp
@@ -47,6 +47,9 @@ class BLSSignature {
     // Initializes from native relic g2 element/
     static BLSSignature FromG2(relic::g2_t* element);
 
+    // Initializes from native relic g2 element with AggregationInfo/
+    static BLSSignature FromG2(relic::g2_t* element, const AggregationInfo &info);
+
     // Copy constructor. Deep copies contents.
     BLSSignature(const BLSSignature &signature);
 
@@ -80,11 +83,10 @@ class BLSSignature {
     // Prevent public construction, force static method
     BLSSignature() {}
 
-    static void CompressPoint(uint8_t* result, relic::g2_t* point);
+    static void CompressPoint(uint8_t* result, const relic::g2_t* point);
 
     // Signature group element
     relic::g2_t sig;
-    uint8_t data[BLSSignature::SIGNATURE_SIZE];
 
     // Optional info about how this was aggregated
     AggregationInfo aggregationInfo;

--- a/src/blssignature.hpp
+++ b/src/blssignature.hpp
@@ -73,7 +73,6 @@ class BLSSignature {
 
     friend bool operator==(BLSSignature const &a, BLSSignature const &b);
     friend bool operator!=(BLSSignature const &a, BLSSignature const &b);
-    friend bool operator<(BLSSignature const &a,  BLSSignature const &b);
     friend std::ostream &operator<<(std::ostream &os, BLSSignature const &s);
     BLSSignature& operator=(const BLSSignature& rhs);
 

--- a/src/blsutil.hpp
+++ b/src/blsutil.hpp
@@ -46,25 +46,18 @@ class BLSUtil {
         relic::md_map_sh256(output, message, messageLen);
     }
 
-    struct BytesCompare32 {
+    template<size_t S>
+    struct BytesCompare {
         bool operator() (const uint8_t* lhs, const uint8_t* rhs) const {
-            for (size_t i = 0; i < 32; i++) {
+            for (size_t i = 0; i < S; i++) {
                 if (lhs[i] < rhs[i]) return true;
                 if (lhs[i] > rhs[i]) return false;
             }
             return false;
         }
     };
-
-    struct BytesCompare80 {
-        bool operator() (const uint8_t* lhs, const uint8_t* rhs) const {
-            for (size_t i = 0; i < 80; i++) {
-                if (lhs[i] < rhs[i]) return true;
-                if (lhs[i] > rhs[i]) return false;
-            }
-            return false;
-        }
-    };
+    typedef struct BytesCompare<32> BytesCompare32;
+    typedef struct BytesCompare<80> BytesCompare80;
 
     static std::string HexStr(const uint8_t* data, size_t len) {
         std::stringstream s;

--- a/src/chaincode.cpp
+++ b/src/chaincode.cpp
@@ -49,3 +49,9 @@ std::ostream &operator<<(std::ostream &os, ChainCode const &s) {
 void ChainCode::Serialize(uint8_t *buffer) const {
     bn_write_bin(buffer, ChainCode::CHAIN_CODE_SIZE, chainCode);
 }
+
+std::vector<uint8_t> ChainCode::Serialize() const {
+    std::vector<uint8_t> data(CHAIN_CODE_SIZE);
+    Serialize(data.data());
+    return data;
+}

--- a/src/chaincode.hpp
+++ b/src/chaincode.hpp
@@ -16,6 +16,7 @@
 #define SRC_CHAINCODE_HPP_
 
 #include <iostream>
+#include <vector>
 
 #include "relic_conf.h"
 
@@ -44,6 +45,7 @@ class ChainCode {
     friend std::ostream &operator<<(std::ostream &os, ChainCode const &s);
 
     void Serialize(uint8_t *buffer) const;
+    std::vector<uint8_t> Serialize() const;
 
  private:
     // Prevent direct construction, use static constructor

--- a/src/extendedprivatekey.cpp
+++ b/src/extendedprivatekey.cpp
@@ -214,5 +214,11 @@ void ExtendedPrivateKey::Serialize(uint8_t *buffer) const {
     sk.Serialize(buffer + 13 + ChainCode::CHAIN_CODE_SIZE);
 }
 
+std::vector<uint8_t> ExtendedPrivateKey::Serialize() const {
+    std::vector<uint8_t> data(EXTENDED_PRIVATE_KEY_SIZE);
+    Serialize(data.data());
+    return data;
+}
+
 // Destructors in BLSPrivateKey and ChainCode handle cleaning of memory
 ExtendedPrivateKey::~ExtendedPrivateKey() {}

--- a/src/extendedprivatekey.hpp
+++ b/src/extendedprivatekey.hpp
@@ -17,6 +17,8 @@
 
 #include "relic_conf.h"
 
+#include <vector>
+
 #if defined GMP && ARITH == GMP
 #include <gmp.h>
 #endif
@@ -78,6 +80,7 @@ class ExtendedPrivateKey {
                            const ExtendedPrivateKey& b);
 
     void Serialize(uint8_t* buffer) const;
+    std::vector<uint8_t> Serialize() const;
 
     ~ExtendedPrivateKey();
 

--- a/src/extendedpublickey.cpp
+++ b/src/extendedpublickey.cpp
@@ -142,3 +142,9 @@ void ExtendedPublicKey::Serialize(uint8_t *buffer) const {
     chainCode.Serialize(buffer + 13);
     pk.Serialize(buffer + 13 + ChainCode::CHAIN_CODE_SIZE);
 }
+
+std::vector<uint8_t> ExtendedPublicKey::Serialize() const {
+    std::vector<uint8_t> data(EXTENDED_PUBLIC_KEY_SIZE);
+    Serialize(data.data());
+    return data;
+}

--- a/src/extendedpublickey.hpp
+++ b/src/extendedpublickey.hpp
@@ -17,6 +17,8 @@
 
 #include "relic_conf.h"
 
+#include <vector>
+
 #if defined GMP && ARITH == GMP
 #include <gmp.h>
 #endif
@@ -70,6 +72,7 @@ class ExtendedPublicKey {
                                     ExtendedPublicKey const &s);
 
     void Serialize(uint8_t *buffer) const;
+    std::vector<uint8_t> Serialize() const;
 
  private:
     // private constructor, force use of static methods

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -292,12 +292,8 @@ TEST_CASE("Signatures") {
         REQUIRE(sig2 == sig3);
         REQUIRE(sig3 != sig4);
 
-        REQUIRE(pk1[0] == pk2[0]);
-        REQUIRE(pk1[15] == pk2[15]);
-        REQUIRE(sig1[16] == sig2[16]);
-        REQUIRE(sig1.begin() + sig1.size() == sig1.end());
-        REQUIRE(sk1.begin() + sk1.size() == sk1.end());
-        REQUIRE(pk1.begin() + pk1.size() == pk1.end());
+        REQUIRE(pk1.Serialize() == pk2.Serialize());
+        REQUIRE(sig1.Serialize() ==  sig2.Serialize());
     }
 
     SECTION("Should serialize and deserialize") {


### PR DESCRIPTION
operator< was the only reason why BLSSignature and BLSPublicKey had too keep internal serialized data up-to-data. This required calling of CompressPoint even if the data was never actually needed.

This PR is a set of refactorings which in the end remove the need for operator< and then finally removes the operator and the data field. 

It also includes a few other refactorings to reduce the amount of copying and serialization needed when sorting public keys and signatures. There is also a fix for a memory leak included.

I also removed the stl-like api (begin/end/size) as the classes were probably never intended to be used in a stl-compatible manner (and thus should not imply compatibility if there is none really). I had to change the python tests for this, but could not test these changes as tests currently fail on master as well.

The result of this PR is that copying and moving around signatures and public keys gets a lot faster. We rely on this to be fast internally as we use a lot of paralellism where ownership of objects is important.

https://github.com/Chia-Network/bls-signatures/commit/42f46606a474d5d31d4243632a1c80a809a4633b is a fix for relic, which I also create a [PR](https://github.com/relic-toolkit/relic/pull/85) for in relic.