### PR TITLE
Don't use -march=native and -mtune=native when compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ ENDIF()
 set(STBIN "OFF" CACHE STRING "")
 
 set(FP_METHD "INTEG;INTEG;INTEG;MONTY;LOWER;SLIDE" CACHE STRING "")
-set(COMP "-O3 -funroll-loops -fomit-frame-pointer -march=native -mtune=native" CACHE STRING "")
+set(COMP "-O3 -funroll-loops -fomit-frame-pointer" CACHE STRING "")
 set(FP_PMERS "off" CACHE STRING "")
 set(FPX_METHD "INTEG;INTEG;LAZYR" CACHE STRING "")
 set(EP_PLAIN "off" CACHE STRING "")


### PR DESCRIPTION
This might result in code not running on other CPUs than the host CPU.
Also fails to cross-compile for ARM.

Benchmarks don't show any measurable performance loss.