### PR TITLE
Fix multiple errors in Chia related changes to relic if ALLOC!=AUTO

### DIFF
--- a/contrib/relic/src/ep/relic_ep_map.c
+++ b/contrib/relic/src/ep/relic_ep_map.c
@@ -159,6 +159,14 @@ void ep_sw_encode(ep_t p, fp_t t) {
 /*============================================================================*/
 
 void ep_map(ep_t p, const uint8_t *msg, int len) {
+	bn_t t0;
+	bn_t t1;
+	fp_t t0p;
+	fp_t t1p;
+	ep_t p0;
+	ep_t p1;
+	bn_t k;
+
 	TRY {
 		uint8_t input[MD_LEN + 5];
 		md_map(input, msg, len);
@@ -168,14 +176,6 @@ void ep_map(ep_t p, const uint8_t *msg, int len) {
 		input[MD_LEN + 1] = 0x31;
 		input[MD_LEN + 2] = 0x5f;
 		input[MD_LEN + 3] = 0x30;
-
-		bn_t t0;
-		bn_t t1;
-		fp_t t0p;
-		fp_t t1p;
-		ep_t p0;
-		ep_t p1;
-		bn_t k;
 
 		fp_new(t0p);
 		fp_new(t1p);

--- a/contrib/relic/src/ep/relic_ep_pck.c
+++ b/contrib/relic/src/ep/relic_ep_pck.c
@@ -61,9 +61,13 @@ void ep_pck(ep_t r, const ep_t p) {
 
 int ep_upk(ep_t r, const ep_t p) {
 	fp_t t;
+	bn_t halfQ;
+	bn_t yValue;
 	int result = 0;
 
 	fp_null(t);
+	bn_null(halfQ);
+	bn_null(yValue);
 
 	TRY {
 		fp_new(t);
@@ -76,15 +80,11 @@ int ep_upk(ep_t r, const ep_t p) {
 		if (result) {
 			/* Verify whether the y coordinate is the larger one, matches the
 			 * compressed y-coordinate. */
-			bn_t halfQ;
-			bn_null(halfQ);
 			bn_new(halfQ);
 			halfQ->used = FP_DIGS;
 			dv_copy(halfQ->dp, fp_prime_get(), FP_DIGS);
 			bn_hlv(halfQ, halfQ);
 
-			bn_t yValue;
-			bn_null(yValue);
 			bn_new(yValue);
 			fp_prime_back(yValue, t);
 			int b = bn_cmp(yValue, halfQ) == CMP_GT;

--- a/contrib/relic/src/epx/relic_ep2_map.c
+++ b/contrib/relic/src/epx/relic_ep2_map.c
@@ -90,6 +90,15 @@ void ep2_sw_encode(ep2_t p, fp2_t t) {
 		if (parity) {
 			ep2_neg(p, p);
 		}
+		fp2_free(nt);
+		fp2_free(w);
+		fp2_free(b);
+		bn_free(s_n3);
+		bn_free(s_n3m1o2);
+		fp2_free(x1);
+		fp2_free(x2);
+		fp2_free(x3);
+		fp2_free(rhs);
 		return;
 	}
 
@@ -174,7 +183,7 @@ void ep2_sw_encode(ep2_t p, fp2_t t) {
 		ep2_neg(p, p);
 	}
 
-	fp_free(nt);
+	fp2_free(nt);
 	fp2_free(w);
 	fp2_free(b);
 	bn_free(s_n3);
@@ -183,6 +192,10 @@ void ep2_sw_encode(ep2_t p, fp2_t t) {
 	fp2_free(x2);
 	fp2_free(x3);
 	fp2_free(rhs);
+
+	fp2_free(s_n3p);
+	fp2_free(s_n3m1o2p);
+	fp2_free(ny);
 }
 
 
@@ -301,6 +314,32 @@ void ep2_mul_cof_b12(ep2_t r, ep2_t p) {
 /*============================================================================*/
 
 void ep2_map(ep2_t p, const uint8_t *msg, int len, int performHash) {
+	bn_t t00;
+	bn_t t01;
+	bn_t t10;
+	bn_t t11;
+	fp_t t00p;
+	fp_t t01p;
+	fp_t t10p;
+	fp_t t11p;
+	fp2_t t0p;
+	fp2_t t1p;
+	ep2_t p0;
+	ep2_t p1;
+
+	bn_null(t00);
+	bn_null(t01);
+	bn_null(t10);
+	bn_null(t11);
+	fp_null(t00p);
+	fp_null(t01p);
+	fp_null(t10p);
+	fp_null(t11p);
+	fp2_null(t0p);
+	fp2_null(t1p);
+	ep2_null(p1);
+	ep2_null(p0);
+
 	TRY {
 		uint8_t input[MD_LEN + 8];
 		if (performHash) {
@@ -319,19 +358,6 @@ void ep2_map(ep2_t p, const uint8_t *msg, int len, int performHash) {
 		input[MD_LEN + 4] = 0x5f; // _
 		input[MD_LEN + 5] = 0x63; // c
 		input[MD_LEN + 6] = 0x30; // 0
-
-		bn_t t00;
-		bn_t t01;
-		bn_t t10;
-		bn_t t11;
-		fp_t t00p;
-		fp_t t01p;
-		fp_t t10p;
-		fp_t t11p;
-		fp2_t t0p;
-		fp2_t t1p;
-		ep2_t p0;
-		ep2_t p1;
 
 		bn_new(t00);
 		bn_new(t01);
@@ -425,7 +451,7 @@ void ep2_map(ep2_t p, const uint8_t *msg, int len, int performHash) {
 				} else {
 					ep2_mul(p, p0, x);
 				}
-				bn_free(k);
+				bn_free(x);
 				break;
 			}
 		}
@@ -434,8 +460,6 @@ void ep2_map(ep2_t p, const uint8_t *msg, int len, int performHash) {
 		THROW(ERR_CAUGHT);
 	}
 	FINALLY {
-		ep_free(p0);
-		ep_free(p1);
 		fp2_free(t0p);
 		fp2_free(t1p);
 		fp_free(t00p);

--- a/contrib/relic/src/epx/relic_ep2_pck.c
+++ b/contrib/relic/src/epx/relic_ep2_pck.c
@@ -64,9 +64,13 @@ void ep2_pck(ep2_t r, ep2_t p) {
 
 int ep2_upk(ep2_t r, ep2_t p) {
 	fp2_t t;
+	bn_t halfQ;
+	bn_t yValue;
 	int result = 0;
 
 	fp2_null(t);
+	bn_null(halfQ);
+	bn_null(yValue);
 
 	TRY {
 		fp2_new(t);
@@ -79,15 +83,11 @@ int ep2_upk(ep2_t r, ep2_t p) {
 		if (result) {
 			/* Verify whether the y coordinate is the larger one, matches the
 			 * compressed y-coordinate. */
-			bn_t halfQ;
-			bn_null(halfQ);
 			bn_new(halfQ);
 			halfQ->used = FP_DIGS;
 			dv_copy(halfQ->dp, fp_prime_get(), FP_DIGS);
 			bn_hlv(halfQ, halfQ);
 
-			bn_t yValue;
-			bn_null(yValue);
 			bn_new(yValue);
 			fp_prime_back(yValue, t[1]);
 

--- a/contrib/relic/src/fp/relic_fp_inv.c
+++ b/contrib/relic/src/fp/relic_fp_inv.c
@@ -436,6 +436,12 @@ void fp_inv_sim(fp_t *c, const fp_t *a, int n) {
 void fp_inv_exgcd_bn(bn_t c, const bn_t u, const bn_t p) {
 	bn_t v, g1, g2, q, r;
 
+	bn_null(v);
+	bn_null(g1);
+	bn_null(g2);
+	bn_null(q);
+	bn_null(r);
+
 	TRY {
 		bn_new(v);
 		bn_new(g1);
@@ -471,4 +477,11 @@ void fp_inv_exgcd_bn(bn_t c, const bn_t u, const bn_t p) {
 	CATCH_ANY {
 		THROW(ERR_CAUGHT);
 	}
+	FINALLY {
+		bn_free(v);
+		bn_free(g1);
+		bn_free(g2);
+		bn_free(q);
+		bn_free(r);
+	};
 }


### PR DESCRIPTION
These are mostly compilation errors and a few fixes for memory leaks.

I encountered these while trying to build and test the library with ALLOC=DYNAMIC. This PR only fixes the issues which I found in the relic source. There are much more issues with the BLS library, but I'm not going to create a PR for those...these required much more changes. And instead of fixing the issues on that level, I'd suggest to implement small C++ wrappers around relic::bn_t, relic::ep_t and relic::ep2_t which do the appropriate relic::xxx_new/relic::xxx_free calls in constructors/destructors. This way you'd catch all possible memory leaks and clean up the code as well.

I decided to create this PR so that whenever you decide to backport the `ep_map` related changes to upstream, these changes are included.

And FYI (not really related to this PR), the tests I did with ALLOC=DYNAMIC were a dead end. As expected, it got slower in single threaded environment, but my hope was that it would improve multithreaded environments, where currently parallel verification does not scale after about 4 threads on my system (with 8 cores). I assume that the issues I have with multithreading are in some way related to L1/L2 cache issues and as I had no idea how to fix this, I gave ALLOC=DYNAMIC a try to compare it ;)