### PR TITLE
Remove use/wrapping of C includes with libsodium and relic namespace

### DIFF
--- a/python-bindings/pythonbindings.cpp
+++ b/python-bindings/pythonbindings.cpp
@@ -23,7 +23,7 @@ namespace py = pybind11;
 using namespace bls;
 
 PYBIND11_MODULE(blspy, m) {
-    py::class_<relic::bn_t*>(m, "bn_ptr");
+    py::class_<bn_t*>(m, "bn_ptr");
 
     py::class_<AggregationInfo>(m, "AggregationInfo")
         .def("from_msg_hash", [](const PublicKey &pk, const py::bytes &b) {

--- a/src/aggregationinfo.cpp
+++ b/src/aggregationinfo.cpp
@@ -30,7 +30,7 @@ AggregationInfo AggregationInfo::FromMsgHash(const PublicKey &pk,
     std::memcpy(mapKey, messageHash, BLS::MESSAGE_HASH_LEN);
     pk.Serialize(mapKey + BLS::MESSAGE_HASH_LEN);
     AggregationInfo::AggregationTree tree;
-    relic::bn_t *one = new relic::bn_t[1];
+    bn_t *one = new bn_t[1];
     bn_new(*one);
     bn_zero(*one);
     bn_set_dig(*one, 1);
@@ -53,7 +53,7 @@ AggregationInfo AggregationInfo::FromMsg(const PublicKey &pk,
 AggregationInfo AggregationInfo::FromVectors(
         std::vector<PublicKey> const &pubKeys,
         std::vector<uint8_t*> const &messageHashes,
-        std::vector<relic::bn_t*> const &exponents) {
+        std::vector<bn_t*> const &exponents) {
     if (pubKeys.size() != messageHashes.size() || messageHashes.size() !=
             exponents.size()) {
          throw std::string(("Invalid input, all std::vectors must have\
@@ -65,7 +65,7 @@ AggregationInfo AggregationInfo::FromVectors(
                                        PublicKey::PUBLIC_KEY_SIZE];
         std::memcpy(mapKey, messageHashes[i], BLS::MESSAGE_HASH_LEN);
         pubKeys[i].Serialize(mapKey + BLS::MESSAGE_HASH_LEN);
-        relic::bn_t *mapValue = new relic::bn_t[1];
+        bn_t *mapValue = new bn_t[1];
         bn_new(*mapValue)
         bn_copy(*mapValue, *exponents[i]);
         tree.insert(std::make_pair(mapKey, mapValue));
@@ -142,7 +142,7 @@ void AggregationInfo::RemoveEntries(std::vector<uint8_t*> const &messages,
         pubKeys[i].Serialize(entry + BLS::MESSAGE_HASH_LEN);
         auto kv = tree.find(entry);
         const uint8_t* first = kv->first;
-        const relic::bn_t* second = kv->second;
+        const bn_t* second = kv->second;
         delete[] second;
         tree.erase(entry);
         delete[] first;
@@ -153,7 +153,7 @@ void AggregationInfo::RemoveEntries(std::vector<uint8_t*> const &messages,
     SortIntoVectors(sortedMessageHashes, sortedPubKeys, tree);
 }
 
-void AggregationInfo::GetExponent(relic::bn_t *result, const uint8_t* messageHash,
+void AggregationInfo::GetExponent(bn_t *result, const uint8_t* messageHash,
                                   const PublicKey &pubKey) const {
     uint8_t mapKey[BLS::MESSAGE_HASH_LEN +
             PublicKey::PUBLIC_KEY_SIZE];
@@ -236,7 +236,7 @@ std::ostream &operator<<(std::ostream &os, AggregationInfo const &a) {
     for (auto &kv : a.tree) {
         os << Util::HexStr(kv.first, 80) << ".." << ":" << std::endl;
         uint8_t str[RELIC_BN_BYTES * 3 + 1];
-        relic::bn_write_bin(str, sizeof(str), *kv.second);
+        bn_write_bin(str, sizeof(str), *kv.second);
         os << Util::HexStr(str + RELIC_BN_BYTES * 3 + 1 - 5, 5)
            << std::endl;
     }
@@ -257,11 +257,11 @@ void AggregationInfo::InsertIntoTree(AggregationInfo::AggregationTree &tree,
                 + PublicKey::PUBLIC_KEY_SIZE];
         std::memcpy(messageCopy, mapEntry.first, BLS::MESSAGE_HASH_LEN
                 + PublicKey::PUBLIC_KEY_SIZE);
-        relic::bn_t * exponent = new relic::bn_t[1];
-        relic::bn_new(*exponent);
+        bn_t * exponent = new bn_t[1];
+        bn_new(*exponent);
         bn_copy(*exponent, *mapEntry.second);
-        relic::bn_t ord;
-        relic::g1_get_ord(ord);
+        bn_t ord;
+        g1_get_ord(ord);
         bn_mod(*exponent, *exponent, ord);
         tree.insert(std::make_pair(messageCopy, exponent));
     }
@@ -338,14 +338,14 @@ AggregationInfo AggregationInfo::SecureMergeInfos(
 
     // Calculate Ts
     // Each T is multiplied with an exponent in one of the collidingInfos
-    relic::bn_t* computedTs = new relic::bn_t[sortedCollidingInfos.size()];
+    bn_t* computedTs = new bn_t[sortedCollidingInfos.size()];
     for (size_t i = 0; i < sortedCollidingInfos.size(); i++) {
         bn_new(computedTs[i]);
     }
     BLS::HashPubKeys(computedTs, sortedCollidingInfos.size(), serPks, sortedKeys);
 
-    relic::bn_t ord;
-    relic::g1_get_ord(ord);
+    bn_t ord;
+    g1_get_ord(ord);
 
     // Merge the trees, multiplying by the Ts, and then adding
     // to total
@@ -361,7 +361,7 @@ AggregationInfo AggregationInfo::SecureMergeInfos(
                 std::memcpy(mapKeyCopy, mapEntry.first, BLS::MESSAGE_HASH_LEN
                     + PublicKey::PUBLIC_KEY_SIZE);
 
-                relic::bn_t * exponent = new relic::bn_t[1];
+                bn_t * exponent = new bn_t[1];
                 bn_new(*exponent);
                 bn_copy(*exponent, *mapEntry.second);
                 bn_mul(*exponent, *exponent, computedTs[i]);
@@ -369,7 +369,7 @@ AggregationInfo AggregationInfo::SecureMergeInfos(
                 newTree.insert(std::make_pair(mapKeyCopy, exponent));
             } else {
                 // This message & pk is already included. Multiply.
-                relic::bn_t tmp;
+                bn_t tmp;
                 bn_new(tmp);
                 bn_copy(tmp, *mapEntry.second);
                 bn_mul(tmp, tmp, computedTs[i]);

--- a/src/aggregationinfo.hpp
+++ b/src/aggregationinfo.hpp
@@ -46,7 +46,7 @@ class AggregationInfo {
     static AggregationInfo FromVectors(
                 std::vector<PublicKey> const &pubKeys,
                 std::vector<uint8_t*> const &messageHashes,
-                std::vector<relic::bn_t*> const &exponents);
+                std::vector<bn_t*> const &exponents);
 
     // Merge two AggregationInfo objects into one.
     static AggregationInfo MergeInfos(std::vector<AggregationInfo>
@@ -60,7 +60,7 @@ class AggregationInfo {
                        std::vector<PublicKey> const &pubKeys);
 
     // Public accessors
-    void GetExponent(relic::bn_t *result, const uint8_t* messageHash,
+    void GetExponent(bn_t *result, const uint8_t* messageHash,
                      const PublicKey &pubkey) const;
     std::vector<PublicKey> GetPubKeys() const;
     std::vector<uint8_t*> GetMessageHashes() const;
@@ -79,7 +79,7 @@ class AggregationInfo {
  private:
     // This is the data structure that maps messages (32) and
     // public keys (48) to exponents (bn_t*).
-    typedef std::map<uint8_t*, relic::bn_t*,
+    typedef std::map<uint8_t*, bn_t*,
                      Util::BytesCompare80> AggregationTree;
 
     explicit AggregationInfo(const AggregationTree& tr,

--- a/src/bls.cpp
+++ b/src/bls.cpp
@@ -30,19 +30,19 @@ bool BLS::Init() {
         std::cout << "Must have ALLOC == AUTO";
         return false;
     }
-    relic::core_init();
-    if (relic::err_get_code() != STS_OK) {
+    core_init();
+    if (err_get_code() != STS_OK) {
         std::cout << "core_init() failed";
         return false;
     }
 
-    const int r = relic::ep_param_set_any_pairf();
+    const int r = ep_param_set_any_pairf();
     if (r != STS_OK) {
         std::cout << "ep_param_set_any_pairf() failed";
         return false;
     }
 #if BLSALLOC_SODIUM
-    if (libsodium::sodium_init() < 0) {
+    if (sodium_init() < 0) {
         std::cout << "libsodium init failed";
         return false;
     }
@@ -51,24 +51,24 @@ bool BLS::Init() {
 }
 
 void BLS::AssertInitialized() {
-    if (!relic::core_get()) {
+    if (!core_get()) {
         throw std::string("Library not initialized properly. Call BLS::Init()");
     }
 #if BLSALLOC_SODIUM
-    if (libsodium::sodium_init() < 0) {
+    if (sodium_init() < 0) {
         throw std::string("Libsodium initialization failed.");
     }
 #endif
 }
 
 void BLS::Clean() {
-    relic::core_clean();
+    core_clean();
 }
 
-void BLS::HashPubKeys(relic::bn_t* output, size_t numOutputs,
+void BLS::HashPubKeys(bn_t* output, size_t numOutputs,
                       std::vector<uint8_t*> const &serPubKeys,
                       std::vector<size_t> const& sortedIndices) {
-    relic::bn_t order;
+    bn_t order;
 
     bn_new(order);
     g2_get_ord(order);
@@ -101,10 +101,10 @@ void BLS::HashPubKeys(relic::bn_t* output, size_t numOutputs,
 }
 
 void BLS::CheckRelicErrors() {
-    if (!relic::core_get()) {
+    if (!core_get()) {
         throw std::string("Library not initialized properly. Call BLS::Init()");
     }
-    if (relic::core_get()->code != STS_OK) {
+    if (core_get()->code != STS_OK) {
         throw std::string("Relic library error");
     }
 }

--- a/src/bls.hpp
+++ b/src/bls.hpp
@@ -31,10 +31,10 @@
 #include "extendedprivatekey.hpp"
 #include "aggregationinfo.hpp"
 
-namespace relic {
-    #include "relic.h"
-    #include "relic_test.h"
-}
+
+#include "relic.h"
+#include "relic_test.h"
+
 namespace bls {
 
 /*
@@ -56,7 +56,7 @@ class BLS {
 
     // Used for secure aggregation
     static void HashPubKeys(
-            relic::bn_t* output,
+            bn_t* output,
             size_t numOutputs,
             std::vector<uint8_t*> const &serPubKeys,
             std::vector<size_t> const &sortedIndices);

--- a/src/chaincode.hpp
+++ b/src/chaincode.hpp
@@ -24,10 +24,9 @@
 #include <gmp.h>
 #endif
 
-namespace relic {
-    #include "relic.h"
-    #include "relic_test.h"
-}
+
+#include "relic.h"
+#include "relic_test.h"
 
 #include "util.hpp"
 namespace bls {
@@ -51,7 +50,7 @@ class ChainCode {
     // Prevent direct construction, use static constructor
     ChainCode() {}
 
-    relic::bn_t chainCode;
+    bn_t chainCode;
 };
 } // end namespace bls
 

--- a/src/extendedprivatekey.cpp
+++ b/src/extendedprivatekey.cpp
@@ -36,14 +36,14 @@ ExtendedPrivateKey ExtendedPrivateKey::FromSeed(const uint8_t* seed,
 
     // Hash the seed into 64 bytes, half will be sk, half will be cc
     hashInput[seedLen] = 0;
-    relic::md_hmac(ILeft, hashInput, seedLen + 1, prefix, sizeof(prefix));
+    md_hmac(ILeft, hashInput, seedLen + 1, prefix, sizeof(prefix));
 
     hashInput[seedLen] = 1;
-    relic::md_hmac(IRight, hashInput, seedLen + 1, prefix, sizeof(prefix));
+    md_hmac(IRight, hashInput, seedLen + 1, prefix, sizeof(prefix));
 
     // Make sure private key is less than the curve order
-    relic::bn_t* skBn = Util::SecAlloc<relic::bn_t>(1);
-    relic::bn_t order;
+    bn_t* skBn = Util::SecAlloc<bn_t>(1);
+    bn_t order;
     bn_new(order);
     g1_get_ord(order);
 
@@ -109,13 +109,13 @@ ExtendedPrivateKey ExtendedPrivateKey::PrivateChild(uint32_t i) const {
     }
     hmacInput[inputLen - 1] = 0;
 
-    relic::md_hmac(ILeft, hmacInput, inputLen,
+    md_hmac(ILeft, hmacInput, inputLen,
                     hmacKey, ChainCode::CHAIN_CODE_SIZE);
 
     // Change 1 byte to generate a different sequence for chaincode
     hmacInput[inputLen - 1] = 1;
 
-    relic::md_hmac(IRight, hmacInput, inputLen,
+    md_hmac(IRight, hmacInput, inputLen,
                     hmacKey, ChainCode::CHAIN_CODE_SIZE);
 
     PrivateKey newSk = PrivateKey::FromBytes(ILeft, true);

--- a/src/extendedprivatekey.hpp
+++ b/src/extendedprivatekey.hpp
@@ -28,10 +28,9 @@
 #include "chaincode.hpp"
 #include "extendedpublickey.hpp"
 
-namespace relic {
-    #include "relic.h"
-    #include "relic_test.h"
-}
+
+#include "relic.h"
+#include "relic_test.h"
 
 namespace bls {
 /*

--- a/src/extendedpublickey.cpp
+++ b/src/extendedpublickey.cpp
@@ -63,13 +63,13 @@ ExtendedPublicKey ExtendedPublicKey::PublicChild(uint32_t i) const {
     hmacInput[inputLen - 1] = 0;
     Util::IntToFourBytes(hmacInput + PublicKey::PUBLIC_KEY_SIZE, i);
 
-    relic::md_hmac(ILeft, hmacInput, inputLen,
+    md_hmac(ILeft, hmacInput, inputLen,
                     hmacKey, ChainCode::CHAIN_CODE_SIZE);
 
     // Change 1 byte to generate a different sequence for chaincode
     hmacInput[inputLen - 1] = 1;
 
-    relic::md_hmac(IRight, hmacInput, inputLen,
+    md_hmac(IRight, hmacInput, inputLen,
                     hmacKey, ChainCode::CHAIN_CODE_SIZE);
 
     PrivateKey leftSk = PrivateKey::FromBytes(ILeft, true);

--- a/src/extendedpublickey.hpp
+++ b/src/extendedpublickey.hpp
@@ -26,10 +26,10 @@
 #include "publickey.hpp"
 #include "chaincode.hpp"
 
-namespace relic {
-    #include "relic.h"
-    #include "relic_test.h"
-}
+
+#include "relic.h"
+#include "relic_test.h"
+
 namespace bls {
 
 /*

--- a/src/privatekey.hpp
+++ b/src/privatekey.hpp
@@ -76,14 +76,14 @@ class PrivateKey {
     PrivateKey() {}
 
     // Multiply private key with n
-    PrivateKey Mul(const relic::bn_t n) const;
+    PrivateKey Mul(const bn_t n) const;
 
     // Allocate memory for private key
     void AllocateKeyData();
 
  private:
     // The actual byte data
-    relic::bn_t *keydata{nullptr};
+    bn_t *keydata{nullptr};
 };
 } // end namespace bls
 

--- a/src/publickey.cpp
+++ b/src/publickey.cpp
@@ -32,11 +32,11 @@ PublicKey PublicKey::FromBytes(const uint8_t * key) {
     } else {
         uncompressed[0] = 0x02;   // Insert extra byte for Y=0
     }
-    relic::g1_read_bin(pk.q, uncompressed, PUBLIC_KEY_SIZE + 1);
+    g1_read_bin(pk.q, uncompressed, PUBLIC_KEY_SIZE + 1);
     return pk;
 }
 
-PublicKey PublicKey::FromG1(const relic::g1_t* pubKey) {
+PublicKey PublicKey::FromG1(const g1_t* pubKey) {
     BLS::AssertInitialized();
     PublicKey pk = PublicKey();
     g1_copy(pk.q, *pubKey);
@@ -86,7 +86,7 @@ PublicKey PublicKey::Aggregate(std::vector<PublicKey> const& pubKeys) {
         return memcmp(serPubKeys[a], serPubKeys[b], PublicKey::PUBLIC_KEY_SIZE) < 0;
     });
 
-    relic::bn_t *computedTs = new relic::bn_t[pubKeysSorted.size()];
+    bn_t *computedTs = new bn_t[pubKeysSorted.size()];
     for (size_t i = 0; i < pubKeysSorted.size(); i++) {
         bn_new(computedTs[i]);
     }
@@ -113,7 +113,7 @@ PublicKey PublicKey::Aggregate(std::vector<PublicKey> const& pubKeys) {
     return aggKey;
 }
 
-PublicKey PublicKey::Exp(relic::bn_t const n) const {
+PublicKey PublicKey::Exp(bn_t const n) const {
     PublicKey ret;
     g1_mul(ret.q, q, n);
     return ret;
@@ -156,7 +156,7 @@ uint32_t PublicKey::GetFingerprint() const {
     return Util::FourBytesToInt(hash);
 }
 
-void PublicKey::CompressPoint(uint8_t* result, const relic::g1_t* point) {
+void PublicKey::CompressPoint(uint8_t* result, const g1_t* point) {
     uint8_t buffer[PublicKey::PUBLIC_KEY_SIZE + 1];
     g1_write_bin(buffer, PublicKey::PUBLIC_KEY_SIZE + 1, *point, 1);
 

--- a/src/publickey.hpp
+++ b/src/publickey.hpp
@@ -38,7 +38,7 @@ class PublicKey {
     static PublicKey FromBytes(const uint8_t* key);
 
     // Construct a public key from a native g1 element.
-    static PublicKey FromG1(const relic::g1_t* key);
+    static PublicKey FromG1(const g1_t* key);
 
     // Construct a public key from another public key.
     PublicKey(const PublicKey &pubKey);
@@ -65,13 +65,13 @@ class PublicKey {
     PublicKey();
 
     // Exponentiate public key with n
-    PublicKey Exp(const relic::bn_t n) const;
+    PublicKey Exp(const bn_t n) const;
 
-    static void CompressPoint(uint8_t* result, const relic::g1_t* point);
+    static void CompressPoint(uint8_t* result, const g1_t* point);
 
  private:
     // Public key group element
-    relic::g1_t q;
+    g1_t q;
 };
 
 } // end namespace bls

--- a/src/signature.cpp
+++ b/src/signature.cpp
@@ -21,8 +21,6 @@
 #include "bls.hpp"
 
 using std::string;
-using relic::bn_t;
-using relic::fp_t;
 namespace bls {
 InsecureSignature InsecureSignature::FromBytes(const uint8_t *data) {
     BLS::AssertInitialized();
@@ -35,14 +33,14 @@ InsecureSignature InsecureSignature::FromBytes(const uint8_t *data) {
     } else {
         uncompressed[0] = 0x02;   // Insert extra byte for Y=0
     }
-    relic::g2_read_bin(sigObj.sig, uncompressed, SIGNATURE_SIZE + 1);
+    g2_read_bin(sigObj.sig, uncompressed, SIGNATURE_SIZE + 1);
     return sigObj;
 }
 
-InsecureSignature InsecureSignature::FromG2(const relic::g2_t* element) {
+InsecureSignature InsecureSignature::FromG2(const g2_t* element) {
     BLS::AssertInitialized();
     InsecureSignature sigObj = InsecureSignature();
-    relic::g2_copy(sigObj.sig, *(relic::g2_t*)element);
+    g2_copy(sigObj.sig, *(g2_t*)element);
     return sigObj;
 }
 
@@ -53,7 +51,7 @@ InsecureSignature::InsecureSignature() {
 
 InsecureSignature::InsecureSignature(const InsecureSignature &signature) {
     BLS::AssertInitialized();
-    g2_copy(sig, *(relic::g2_t*)&signature.sig);
+    g2_copy(sig, *(g2_t*)&signature.sig);
 }
 
 bool InsecureSignature::Verify(const std::vector<const uint8_t*>& hashes,
@@ -62,16 +60,16 @@ bool InsecureSignature::Verify(const std::vector<const uint8_t*>& hashes,
         throw std::string("hashes and pubKeys vectors must be of same size and non-empty");
     }
 
-    relic::g1_t *pubKeysNative = new relic::g1_t[hashes.size() + 1];
-    relic::g2_t *mappedHashes = new relic::g2_t[hashes.size() + 1];
+    g1_t *pubKeysNative = new g1_t[hashes.size() + 1];
+    g2_t *mappedHashes = new g2_t[hashes.size() + 1];
 
-    relic::g2_copy(mappedHashes[0], *(relic::g2_t*)&sig);
-    relic::g1_get_gen(pubKeysNative[0]);
-    relic::bn_t ordMinus1;
-    relic::bn_new(ordMinus1);
-    relic::g1_get_ord(ordMinus1);
-    relic::bn_sub_dig(ordMinus1, ordMinus1, 1);
-    relic::g1_mul(pubKeysNative[0], pubKeysNative[0], ordMinus1);
+    g2_copy(mappedHashes[0], *(g2_t*)&sig);
+    g1_get_gen(pubKeysNative[0]);
+    bn_t ordMinus1;
+    bn_new(ordMinus1);
+    g1_get_ord(ordMinus1);
+    bn_sub_dig(ordMinus1, ordMinus1, 1);
+    g1_mul(pubKeysNative[0], pubKeysNative[0], ordMinus1);
 
     for (size_t i = 0; i < hashes.size(); i++) {
         g2_map(mappedHashes[i + 1], hashes[i], BLS::MESSAGE_HASH_LEN, 0);
@@ -87,23 +85,23 @@ bool InsecureSignature::Verify(const std::vector<const uint8_t*>& hashes,
 }
 
 bool InsecureSignature::VerifyNative(
-        relic::g1_t* pubKeys,
-        relic::g2_t* mappedHashes,
+        g1_t* pubKeys,
+        g2_t* mappedHashes,
         size_t len) {
-    relic::gt_t target, candidate;
+    gt_t target, candidate;
 
     // Target = 1
-    relic::fp12_zero(target);
-    relic::fp_set_dig(target[0][0][0], 1);
+    fp12_zero(target);
+    fp_set_dig(target[0][0][0], 1);
 
     // prod e(pubkey[i], hash[i]) * e(-1 * g1, aggSig)
     // Performs pubKeys.size() pairings
     pc_map_sim(candidate, pubKeys, mappedHashes, len);
 
     // 1 =? prod e(pubkey[i], hash[i]) * e(g1, aggSig)
-    if (relic::gt_cmp(target, candidate) != CMP_EQ ||
-        relic::core_get()->code != STS_OK) {
-        relic::core_get()->code = STS_OK;
+    if (gt_cmp(target, candidate) != CMP_EQ ||
+        core_get()->code != STS_OK) {
+        core_get()->code = STS_OK;
         return false;
     }
     BLS::CheckRelicErrors();
@@ -116,7 +114,7 @@ InsecureSignature InsecureSignature::Aggregate(const std::vector<InsecureSignatu
     }
     InsecureSignature result = sigs[0];
     for (size_t i = 1; i < sigs.size(); i++) {
-        g2_add(result.sig, result.sig, *(relic::g2_t*)&sigs[i].sig);
+        g2_add(result.sig, result.sig, *(g2_t*)&sigs[i].sig);
     }
     return result;
 }
@@ -128,11 +126,11 @@ InsecureSignature InsecureSignature::DivideBy(const std::vector<InsecureSignatur
 
     InsecureSignature tmpAgg = Aggregate(sigs);
     InsecureSignature result(*this);
-    relic::g2_sub(result.sig, result.sig, tmpAgg.sig);
+    g2_sub(result.sig, result.sig, tmpAgg.sig);
     return result;
 }
 
-InsecureSignature InsecureSignature::Exp(const relic::bn_t n) const {
+InsecureSignature InsecureSignature::Exp(const bn_t n) const {
     InsecureSignature result(*this);
     g2_mul(result.sig, result.sig, n);
     return result;
@@ -151,7 +149,7 @@ std::vector<uint8_t> InsecureSignature::Serialize() const {
 
 bool operator==(InsecureSignature const &a, InsecureSignature const &b) {
     BLS::AssertInitialized();
-    return g2_cmp(*(relic::g2_t*)&a.sig, *(relic::g2_t*)b.sig) == CMP_EQ;
+    return g2_cmp(*(g2_t*)&a.sig, *(g2_t*)b.sig) == CMP_EQ;
 }
 
 bool operator!=(InsecureSignature const &a, InsecureSignature const &b) {
@@ -167,13 +165,13 @@ std::ostream &operator<<(std::ostream &os, InsecureSignature const &s) {
 
 InsecureSignature& InsecureSignature::operator=(const InsecureSignature &rhs) {
     BLS::AssertInitialized();
-    relic::g2_copy(sig, *(relic::g2_t*)&rhs.sig);
+    g2_copy(sig, *(g2_t*)&rhs.sig);
     return *this;
 }
 
-void InsecureSignature::CompressPoint(uint8_t* result, const relic::g2_t* point) {
+void InsecureSignature::CompressPoint(uint8_t* result, const g2_t* point) {
     uint8_t buffer[InsecureSignature::SIGNATURE_SIZE + 1];
-    g2_write_bin(buffer, InsecureSignature::SIGNATURE_SIZE + 1, *(relic::g2_t*)point, 1);
+    g2_write_bin(buffer, InsecureSignature::SIGNATURE_SIZE + 1, *(g2_t*)point, 1);
 
     if (buffer[0] == 0x03) {
         buffer[1] |= 0x80;
@@ -195,13 +193,13 @@ Signature Signature::FromBytes(const uint8_t *data, const AggregationInfo &info)
     return ret;
 }
 
-Signature Signature::FromG2(const relic::g2_t* element) {
+Signature Signature::FromG2(const g2_t* element) {
     Signature result;
     result.sig = InsecureSignature::FromG2(element);
     return result;
 }
 
-Signature Signature::FromG2(const relic::g2_t* element, const AggregationInfo& info) {
+Signature Signature::FromG2(const g2_t* element, const AggregationInfo& info) {
     Signature ret = FromG2(element);
     ret.SetAggregationInfo(info);
     return ret;
@@ -311,7 +309,7 @@ bool Signature::Verify() const {
         for (const auto &kv2 : dedupMap) {
             const PublicKey& pk = kv.second[kv2.second];
 
-            relic::bn_t exponent;
+            bn_t exponent;
             bn_new(exponent);
             try {
                 GetAggregationInfo()->GetExponent(&exponent, kv.first, pk);
@@ -410,9 +408,9 @@ Signature Signature::AggregateSigsSecure(
         return memcmp(sortKeys[a], sortKeys[b], BLS::MESSAGE_HASH_LEN + PublicKey::PUBLIC_KEY_SIZE) < 0;
     });
 
-    relic::bn_t* computedTs = new relic::bn_t[keysSorted.size()];
+    bn_t* computedTs = new bn_t[keysSorted.size()];
     for (size_t i = 0; i < keysSorted.size(); i++) {
-        relic::bn_new(computedTs[i]);
+        bn_new(computedTs[i]);
     }
     BLS::HashPubKeys(computedTs, keysSorted.size(), serPubKeys, keysSorted);
 
@@ -551,7 +549,7 @@ Signature Signature::AggregateSigsInternal(
         pubKeysSorted.push_back(PublicKey::FromBytes(sortKey
                                                         + BLS::MESSAGE_HASH_LEN));
     }
-    relic::bn_t* computedTs = new relic::bn_t[sigsSorted.size()];
+    bn_t* computedTs = new bn_t[sigsSorted.size()];
     for (size_t i = 0; i < sigsSorted.size(); i++) {
         bn_new(computedTs[i]);
     }
@@ -616,7 +614,7 @@ Signature Signature::AggregateSigsSimple(std::vector<Signature> const &sigs) {
 }
 
 Signature Signature::DivideBy(std::vector<Signature> const &divisorSigs) const {
-    relic::bn_t ord;
+    bn_t ord;
     g2_get_ord(ord);
 
     std::vector<uint8_t*> messageHashesToRemove;
@@ -632,14 +630,14 @@ Signature Signature::DivideBy(std::vector<Signature> const &divisorSigs) const {
         if (pks.size() != messageHashes.size()) {
             throw string("Invalid aggregation info.");
         }
-        relic::bn_t quotient;
+        bn_t quotient;
         for (size_t i = 0; i < pks.size(); i++) {
-            relic::bn_t divisor;
+            bn_t divisor;
             bn_new(divisor);
             divisorSig.GetAggregationInfo()->GetExponent(&divisor,
                     messageHashes[i],
                     pks[i]);
-            relic::bn_t dividend;
+            bn_t dividend;
             bn_new(dividend);
             try {
                 aggregationInfo.GetExponent(&dividend, messageHashes[i],
@@ -648,18 +646,18 @@ Signature Signature::DivideBy(std::vector<Signature> const &divisorSigs) const {
                 throw string("Signature is not a subset.");
             }
 
-            relic::bn_t inverted;
-            relic::fp_inv_exgcd_bn(inverted, divisor, ord);
+            bn_t inverted;
+            fp_inv_exgcd_bn(inverted, divisor, ord);
 
             if (i == 0) {
-                relic::bn_mul(quotient, dividend, inverted);
-                relic::bn_mod(quotient, quotient, ord);
+                bn_mul(quotient, dividend, inverted);
+                bn_mod(quotient, quotient, ord);
             } else {
-                relic::bn_t newQuotient;
-                relic::bn_mul(newQuotient, dividend, inverted);
-                relic::bn_mod(newQuotient, newQuotient, ord);
+                bn_t newQuotient;
+                bn_mul(newQuotient, dividend, inverted);
+                bn_mod(newQuotient, newQuotient, ord);
 
-                if (relic::bn_cmp(quotient, newQuotient) != CMP_EQ) {
+                if (bn_cmp(quotient, newQuotient) != CMP_EQ) {
                     throw string("Cannot divide by aggregate signature,"
                                  "msg/pk pairs are not unique");
                 }

--- a/src/signature.hpp
+++ b/src/signature.hpp
@@ -41,7 +41,7 @@ class InsecureSignature {
     static InsecureSignature FromBytes(const uint8_t *data);
 
     // Initializes from native relic g2 element/
-    static InsecureSignature FromG2(const relic::g2_t* element);
+    static InsecureSignature FromG2(const g2_t* element);
 
     // Copy constructor. Deep copies contents.
     InsecureSignature(const InsecureSignature &signature);
@@ -70,21 +70,21 @@ class InsecureSignature {
     InsecureSignature();
 
     // Exponentiate signature with n
-    InsecureSignature Exp(const relic::bn_t n) const;
+    InsecureSignature Exp(const bn_t n) const;
 
-    static void CompressPoint(uint8_t* result, const relic::g2_t* point);
+    static void CompressPoint(uint8_t* result, const g2_t* point);
 
     // Performs multipairing and checks that everything matches. This is an
     // internal method, only called from Verify. It should not be used
     // anywhere else.
     static bool VerifyNative(
-            relic::g1_t* pubKeys,
-            relic::g2_t* mappedHashes,
+            g1_t* pubKeys,
+            g2_t* mappedHashes,
             size_t len);
 
  private:
     // Signature group element
-    relic::g2_t sig;
+    g2_t sig;
 };
 
 /**
@@ -105,10 +105,10 @@ class Signature {
     static Signature FromBytes(const uint8_t *data, const AggregationInfo &info);
 
     // Initializes from native relic g2 element/
-    static Signature FromG2(const relic::g2_t* element);
+    static Signature FromG2(const g2_t* element);
 
     // Initializes from native relic g2 element with AggregationInfo/
-    static Signature FromG2(const relic::g2_t* element, const AggregationInfo &info);
+    static Signature FromG2(const g2_t* element, const AggregationInfo &info);
 
     // Initializes from insecure signature/
     static Signature FromInsecureSig(const InsecureSignature& sig);

--- a/src/test-utils.hpp
+++ b/src/test-utils.hpp
@@ -43,7 +43,7 @@ void endStopwatch(string testName,
 }
 
 void getRandomSeed(uint8_t* seed) {
-    relic::bn_t r;
+    bn_t r;
     bn_new(r);
     bn_rand(r, BN_POS, 256);
     bn_write_bin(seed, 32, r);

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -188,7 +188,7 @@ TEST_CASE("Key generation") {
 
         PrivateKey sk = PrivateKey::FromSeed(seed, sizeof(seed));
         PublicKey pk = sk.GetPublicKey();
-        REQUIRE(relic::core_get()->code == STS_OK);
+        REQUIRE(core_get()->code == STS_OK);
         REQUIRE(pk.GetFingerprint() == 0xddad59bb);
     }
 }
@@ -239,10 +239,10 @@ TEST_CASE("Signatures") {
 
         // Hashing to g1
         uint8_t mapMsg[0] = {};
-        relic::g1_t result;
+        g1_t result;
         uint8_t buf[49];
-        relic::ep_map(result, mapMsg, 0);
-        relic::g1_write_bin(buf, 49, result, 1);
+        ep_map(result, mapMsg, 0);
+        g1_write_bin(buf, 49, result, 1);
         REQUIRE(Util::HexStr(buf + 1, 48) == "12fc5ad5a2fbe9d4b6eb0bc16d530e5f263b6d59cbaf26c3f2831962924aa588ab84d46cc80d3a433ce064adb307f256");
     }
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -28,23 +28,21 @@
 #endif
 
 #if BLSALLOC_SODIUM
-namespace libsodium {
-    #include "sodium/utils.h"
-    #include "sodium/core.h"
-}
+#include "sodium/utils.h"
+#include "sodium/core.h"
 #endif
 
-namespace relic {
-    #include "relic.h"
-    #include "relic_test.h"
-}
+
+#include "relic.h"
+#include "relic_test.h"
+
 namespace bls {
 
 class Util {
  public:
     static void Hash256(uint8_t* output, const uint8_t* message,
                         size_t messageLen) {
-        relic::md_map_sh256(output, message, messageLen);
+        md_map_sh256(output, message, messageLen);
     }
 
     template<size_t S>
@@ -75,7 +73,7 @@ class Util {
     template<class T>
     static T* SecAlloc(size_t numTs) {
 #if BLSALLOC_SODIUM
-        return static_cast<T*>(libsodium::sodium_malloc
+        return static_cast<T*>(sodium_malloc
                 (sizeof(T) * numTs));
 #else
         return static_cast<T*>(malloc(sizeof(T) * numTs));
@@ -87,7 +85,7 @@ class Util {
      */
     static void SecFree(void* ptr) {
 #if BLSALLOC_SODIUM
-        libsodium::sodium_free(ptr);
+        sodium_free(ptr);
 #else
         free(ptr);
 #endif


### PR DESCRIPTION
Don't use namespaces libsodium or relic for C types/functions.
Don't wrap C header files inside those namespaces to avoid possible future issues
