### PR TITLE
Allow setting secure allocator from outside

### DIFF
--- a/src/bls.cpp
+++ b/src/bls.cpp
@@ -25,6 +25,9 @@ const char BLS::GROUP_ORDER[] =
 
 bool BLSInitResult = BLS::Init();
 
+Util::SecureAllocCallback Util::secureAllocCallback;
+Util::SecureFreeCallback Util::secureFreeCallback;
+
 bool BLS::Init() {
     if (ALLOC != AUTO) {
         std::cout << "Must have ALLOC == AUTO";
@@ -46,6 +49,9 @@ bool BLS::Init() {
         std::cout << "libsodium init failed";
         return false;
     }
+    SetSecureAllocator(libsodium::sodium_malloc, libsodium::sodium_free);
+#else
+    SetSecureAllocator(malloc, free);
 #endif
     return true;
 }
@@ -63,6 +69,11 @@ void BLS::AssertInitialized() {
 
 void BLS::Clean() {
     core_clean();
+}
+
+void BLS::SetSecureAllocator(Util::SecureAllocCallback allocCb, Util::SecureFreeCallback freeCb) {
+    Util::secureAllocCallback = allocCb;
+    Util::secureFreeCallback = freeCb;
 }
 
 void BLS::HashPubKeys(bn_t* output, size_t numOutputs,

--- a/src/bls.hpp
+++ b/src/bls.hpp
@@ -54,6 +54,8 @@ class BLS {
     // Cleans the BLS library
     static void Clean();
 
+    static void SetSecureAllocator(Util::SecureAllocCallback allocCb, Util::SecureFreeCallback freeCb);
+
     // Used for secure aggregation
     static void HashPubKeys(
             bn_t* output,

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -27,18 +27,17 @@
 #include <gmp.h>
 #endif
 
-#if BLSALLOC_SODIUM
-#include "sodium/utils.h"
-#include "sodium/core.h"
-#endif
-
-
 #include "relic.h"
 #include "relic_test.h"
 
 namespace bls {
 
+class BLS;
+
 class Util {
+ public:
+    typedef void *(*SecureAllocCallback)(size_t);
+    typedef void (*SecureFreeCallback)(void*);
  public:
     static void Hash256(uint8_t* output, const uint8_t* message,
                         size_t messageLen) {
@@ -72,23 +71,14 @@ class Util {
      */
     template<class T>
     static T* SecAlloc(size_t numTs) {
-#if BLSALLOC_SODIUM
-        return static_cast<T*>(sodium_malloc
-                (sizeof(T) * numTs));
-#else
-        return static_cast<T*>(malloc(sizeof(T) * numTs));
-#endif
+        return static_cast<T*>(secureAllocCallback(sizeof(T) * numTs));
     }
 
     /*
      * Frees memory allocated using SecAlloc.
      */
     static void SecFree(void* ptr) {
-#if BLSALLOC_SODIUM
-        sodium_free(ptr);
-#else
-        free(ptr);
-#endif
+        secureFreeCallback(ptr);
     }
 
     /*
@@ -112,6 +102,11 @@ class Util {
         }
         return sum;
     }
+
+ private:
+    friend class BLS;
+    static SecureAllocCallback secureAllocCallback;
+    static SecureFreeCallback secureFreeCallback;
 };
 } // end namespace bls
 #endif  // SRC_BLSUTIL_HPP_


### PR DESCRIPTION
This is useful when the surrounding application already has a framework for secure allocation (e.g. Bitcoin/Dash LockedPool).