### PR TITLE
Convert relic stuff to UTF-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/*
 blspy.egg-info
 dist
 python-impl/__pycache__/
+blspy.*.so
 
 main
 .o

--- a/contrib/relic/cmake/eb.cmake
+++ b/contrib/relic/cmake/eb.cmake
@@ -13,7 +13,7 @@ message("   ** Available binary elliptic curve methods (default = PROJC;LWNAF;CO
 
 message("      Point representation:")
 message("      EB_METHD=BASIC    Affine coordinates.")
-message("      EB_METHD=PROJC    Projective coordinates (López-Dahab for ordinary curves).\n")
+message("      EB_METHD=PROJC    Projective coordinates (LÃ³pez-Dahab for ordinary curves).\n")
 
 message("      Variable-base scalar multiplication:")
 message("      EB_METHD=BASIC    Binary double-and-add method.")

--- a/contrib/relic/cmake/fb.cmake
+++ b/contrib/relic/cmake/fb.cmake
@@ -16,7 +16,7 @@ message("      FB_METHD=BASIC    Right-to-left shift-and-add multiplication.")
 message("      FB_METHD=INTEG    Integrated modular multiplication.")
 message("      FB_METHD=RCOMB    Right-to-left comb multiplication.")
 message("      FB_METHD=LCOMB    Left-to-right comb multiplication.")
-message("      FB_METHD=LODAH    López-Dahab comb multiplication with window of width 4.\n")
+message("      FB_METHD=LODAH    LÃ³pez-Dahab comb multiplication with window of width 4.\n")
 
 message("      Field squaring:")
 message("      FB_METHD=BASIC    Bit manipulation squaring.")

--- a/contrib/relic/include/relic_conf.h.in
+++ b/contrib/relic/include/relic_conf.h.in
@@ -306,7 +306,7 @@
 
 /** Shift-and-add multiplication. */
 #define BASIC    1
-/** Lopez-Dahab multiplication. */
+/** López-Dahab multiplication. */
 #define LODAH	 2
 /** Integrated modular multiplication. */
 #define INTEG	 3
@@ -470,14 +470,14 @@
 
 /** Affine coordinates. */
 #define BASIC	 1
-/** L�pez-Dahab Projective coordinates. */
+/** López-Dahab Projective coordinates. */
 #define PROJC	 2
 /** Chosen binary elliptic curve coordinate method. */
 #define EB_ADD	 @EB_ADD@
 
 /** Binary point multiplication. */
 #define BASIC	 1
-/** L�pez-Dahab point multiplication. */
+/** López-Dahab point multiplication. */
 #define LODAH	 2
 /** Halving. */
 #define HALVE    3


### PR DESCRIPTION
This prevents pip from choking on the build output like so:

```
$ pip3 install --user blspy==0.1.5
Collecting blspy==0.1.5
  Using cached https://files.pythonhosted.org/packages/1d/29/3bb073a1d4571989e6a88703cb7f28d39f73bf097d4402c3859edb9868cf/blspy-0.1.5.tar.gz
Building wheels for collected packages: blspy
  Running setup.py bdist_wheel for blspy ... error
  Failed building wheel for blspy
  Running setup.py clean for blspy
Failed to build blspy
Installing collected packages: blspy
  Running setup.py install for blspy ... error
Exception:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pip/compat/__init__.py", line 73, in console_to_str
    return s.decode(sys.stdout.encoding)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf3 in position 25: invalid continuation byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/usr/lib/python3/dist-packages/pip/commands/install.py", line 360, in run
    prefix=options.prefix_path,
  File "/usr/lib/python3/dist-packages/pip/req/req_set.py", line 784, in install
    **kwargs
  File "/usr/lib/python3/dist-packages/pip/req/req_install.py", line 878, in install
    spinner=spinner,
  File "/usr/lib/python3/dist-packages/pip/utils/__init__.py", line 694, in call_subprocess
    line = console_to_str(proc.stdout.readline())
  File "/usr/lib/python3/dist-packages/pip/compat/__init__.py", line 75, in console_to_str
    return s.decode('utf_8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf3 in position 25: invalid continuation byte
```