### PR TITLE
support mcl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "contrib/pybind11"]
 	path = contrib/pybind11
 	url = https://github.com/pybind/pybind11.git
+[submodule "contrib/mcl"]
+	path = contrib/mcl
+	url = https://github.com/herumi/mcl

--- a/python-bindings/CMakeLists.txt
+++ b/python-bindings/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../contrib/relic/include
   ${CMAKE_BINARY_DIR}/contrib/relic/include
   ${CMAKE_CURRENT_SOURCE_DIR}/../contrib/catch
+  ${CMAKE_CURRENT_SOURCE_DIR}/../contrib/mcl/include
   )
 
 pybind11_add_module(blspy ${CMAKE_CURRENT_SOURCE_DIR}/pythonbindings.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../contrib/relic/include
   ${CMAKE_BINARY_DIR}/contrib/relic/include
   ${CMAKE_CURRENT_SOURCE_DIR}/../contrib/catch
+  ${CMAKE_CURRENT_SOURCE_DIR}/../contrib/mcl/include
   )
 
 set(C_LIB ${CMAKE_BINARY_DIR}/libbls.a)
@@ -25,7 +26,10 @@ add_library(blstmp ${HEADERS}
   ${CMAKE_CURRENT_SOURCE_DIR}/bls.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/aggregationinfo.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/threshold.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../contrib/mcl/src/fp.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../contrib/mcl/src/bn_c384_256.cpp
 )
+target_link_libraries(blstmp crypto)
 
 set(OPREFIX object_)
 find_library(GMP_NAME NAMES libgmp.a gmp)
@@ -66,11 +70,14 @@ install(FILES ${C_LIB} DESTINATION lib)
 
 add_executable(runtest test.cpp)
 add_executable(runbench test-bench.cpp)
+add_executable(runmcl test-mcl.cpp)
 
 if (SODIUM_FOUND)
   target_link_libraries(runtest blstmp relic_s sodium)
   target_link_libraries(runbench blstmp relic_s sodium)
+  target_link_libraries(runmcl blstmp relic_s sodium)
 else()
   target_link_libraries(runtest blstmp relic_s)
   target_link_libraries(runbench blstmp relic_s)
+  target_link_libraries(runmcl blstmp relic_s)
 endif()

--- a/src/bls.cpp
+++ b/src/bls.cpp
@@ -22,6 +22,7 @@ namespace bls {
 
 const char BLS::GROUP_ORDER[] =
         "73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001";
+mclBnG1 BLS::mclG1gen;
 
 bool BLSInitResult = BLS::Init();
 
@@ -41,6 +42,20 @@ static void relic_core_initializer(void* ptr) {
         std::cout << "ep_param_set_any_pairf() failed";
         // this will most likely crash the application...but there isn't much we can do
         throw std::string("ep_param_set_any_pairf() failed");
+    }
+    /*
+      SecretKey : keydata : *bn_t
+      PublicKey : q : g1_t
+      InsecureSignature : sig : g2_t
+    */
+    if (mclBn_init(MCL_BLS12_381, MCLBN_COMPILED_TIME_VAR) != 0) {
+        throw std::string("mcl init failed");
+    }
+    {
+        g1_t g1;
+        g1_new(g1);
+        g1_get_gen(g1);
+        mcl::conv(&BLS::mclG1gen, &g1);
     }
 }
 

--- a/src/bls.hpp
+++ b/src/bls.hpp
@@ -47,6 +47,7 @@ class BLS {
     // Order of g1, g2, and gt. Private keys are in {0, GROUP_ORDER}.
     static const char GROUP_ORDER[];
     static const size_t MESSAGE_HASH_LEN = 32;
+    static mclBnG1 mclG1gen;
 
     // Initializes the BLS library (called automatically)
     static bool Init();

--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -213,7 +213,16 @@ InsecureSignature PrivateKey::SignInsecurePrehashed(const uint8_t *messageHash) 
     g2_t sig, point;
 
     g2_map(point, messageHash, BLS::MESSAGE_HASH_LEN, 0);
+#if 1
+    mclBnG2 sig2;
+    mclBnFr keydata2;
+    mcl::conv(&keydata2, keydata);
+    mcl::conv(&sig2, &point);
+    mclBnG2_mul(&sig2, &sig2, &keydata2);
+    mcl::conv(&sig, &sig2);
+#else
     g2_mul(sig, point, *keydata);
+#endif
 
     return InsecureSignature::FromG2(&sig);
 }

--- a/src/publickey.cpp
+++ b/src/publickey.cpp
@@ -107,9 +107,18 @@ PublicKey PublicKey::Aggregate(std::vector<PublicKey> const& pubKeys) {
     return aggKey;
 }
 
-PublicKey PublicKey::Exp(bn_t const n) const {
+PublicKey PublicKey::Exp(const bn_t& n) const {
     PublicKey ret;
+#if 1
+    mclBnG1 qq;
+    mclBnFr nn;
+    mcl::conv(&nn, &n);
+    mcl::conv(&qq, &q);
+    mclBnG1_mul(&qq, &qq, &nn);
+    mcl::conv(&ret.q, &qq);
+#else
     g1_mul(ret.q, q, n);
+#endif
     return ret;
 }
 

--- a/src/publickey.hpp
+++ b/src/publickey.hpp
@@ -67,7 +67,7 @@ class PublicKey {
     PublicKey();
 
     // Exponentiate public key with n
-    PublicKey Exp(const bn_t n) const;
+    PublicKey Exp(const bn_t& n) const;
 
     static void CompressPoint(uint8_t* result, const g1_t* point);
 

--- a/src/signature.hpp
+++ b/src/signature.hpp
@@ -74,7 +74,7 @@ class InsecureSignature {
     InsecureSignature();
 
     // Exponentiate signature with n
-    InsecureSignature Exp(const bn_t n) const;
+    InsecureSignature Exp(const bn_t& n) const;
 
     static void CompressPoint(uint8_t* result, const g2_t* point);
 

--- a/src/test-mcl.cpp
+++ b/src/test-mcl.cpp
@@ -1,0 +1,189 @@
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+#include "bls.hpp"
+#include "test-utils.hpp"
+#include "relic.h"
+#include "relic_test.h"
+
+using namespace bls;
+
+void dump(const bn_t *v)
+{
+    const int n = v[0]->used;
+    printf("sizeof(dp)=%zd BN_SIZE=%d\n", sizeof(v[0]->dp), BN_SIZE);
+    printf("sign=%d, used=%d\n", v[0]->sign, n);
+    for (int i = 0; i < n; i++) {
+        printf("%016lx ", v[0]->dp[i]);
+    }
+    printf("\n");
+}
+
+void dump(const fp_st *v)
+{
+    printf("sizeof=%zd\n", sizeof(fp_st));
+    for (size_t i = 0; i < sizeof(fp_st) / 8; i++) {
+        printf("%016lx ", v[0][i]);
+    }
+    printf("\n");
+    mclBnFp x = *(const mclBnFp*)v[0];
+    char buf[128];
+    mclBnFp_getStr(buf, sizeof(buf), &x, 16);
+    printf("fp=%s\n", buf);
+}
+void dump(const g1_t *v)
+{
+    char buf[128];
+    fp_write_str(buf, sizeof(buf), v[0]->x, 16);
+    printf("%s ", buf);
+    printf("\n");dump(&v[0]->x);
+    fp_write_str(buf, sizeof(buf), v[0]->y, 16);
+    printf("%s ", buf);
+    fp_write_str(buf, sizeof(buf), v[0]->z, 16);
+    printf("%s ", buf);
+    printf("(%d)\n", v[0]->norm);
+}
+
+void dump(const mclBnG1 *v)
+{
+    const int IoEcProj = 1024;
+    char buf[256];
+    mclBnG1_getStr(buf, sizeof(buf), v, IoEcProj | 16);
+    printf("%s\n", buf);
+}
+
+TEST_CASE("conv") {
+    SECTION("Fr") {
+        char buf[128];
+        bn_t x, y;
+        bn_new(x);
+        bn_new(y);
+        bn_set_dig(x, 123);
+        mclBnFr xx, yy;
+        mcl::conv(&xx, &x);
+        mclBnFr_getStr(buf, sizeof(buf), &xx, 10);
+        REQUIRE(strcmp(buf, "123") == 0);
+
+        const char *s = "1234abcdef1234abcef";
+        bn_read_str(x, s, strlen(s), 16);
+        mclBnFr_setStr(&xx, s, strlen(s), 16);
+        mcl::conv(&yy, &x);
+        REQUIRE(mclBnFr_isEqual(&xx, &yy));
+
+        mcl::conv(&y, &xx);
+        REQUIRE(bn_cmp(x, y) == CMP_EQ);
+    }
+    SECTION("G1") {
+        char buf[256];
+        g1_t x, y, z;
+        g1_new(x);
+        g1_new(y);
+        g1_get_gen(x);
+        mclBnG1 xx, yy, zz;
+        mcl::conv(&xx, &x);
+        g1_dbl(y, x);
+        mclBnG1_dbl(&yy, &xx);
+        mcl::conv(&z, &yy);
+        mcl::conv(&zz, &y);
+        REQUIRE(mclBnG1_isEqual(&yy, &zz));
+        REQUIRE(g1_cmp(y, z) == CMP_EQ);
+
+        g1_add(x, x, y);
+        mclBnG1_add(&xx, &xx, &yy);
+        mcl::conv(&zz, &x);
+        mcl::conv(&z, &xx);
+        REQUIRE(mclBnG1_isEqual(&zz, &xx));
+        REQUIRE(g1_cmp(z, x) == CMP_EQ);
+    }
+    SECTION("G2") {
+        char buf[256];
+        g2_t x, y, z;
+        g2_new(x);
+        g2_new(y);
+        g2_get_gen(x);
+        mclBnG2 xx, yy, zz;
+        mcl::conv(&xx, &x);
+        g2_dbl(y, x);
+        mclBnG2_dbl(&yy, &xx);
+        mcl::conv(&z, &yy);
+        mcl::conv(&zz, &y);
+        REQUIRE(mclBnG2_isEqual(&yy, &zz));
+        REQUIRE(g2_cmp(y, z) == CMP_EQ);
+
+        g2_add(x, x, y);
+        mclBnG2_add(&xx, &xx, &yy);
+        mcl::conv(&zz, &x);
+        mcl::conv(&z, &xx);
+        REQUIRE(mclBnG2_isEqual(&zz, &xx));
+        REQUIRE(g2_cmp(z, x) == CMP_EQ);
+    }
+    SECTION("bench") {
+        const char *rStr = "72EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001";
+        const double numIters = 1000;
+        g1_t x;
+        g2_t y;
+        bn_t s;
+        mclBnG1 xx, t1;
+        mclBnG2 yy, t2;
+        mclBnFr ss;
+        g1_new(x);
+        g2_new(y);
+        bn_new(s);
+        g1_get_gen(x);
+        g2_get_gen(y);
+        bn_read_str(s, rStr, strlen(rStr), 16);
+        mcl::conv(&xx, &x);
+        mcl::conv(&yy, &y);
+        mcl::conv(&ss, &s);
+
+        auto start = startStopwatch();
+        for (size_t i = 0; i < numIters; i++) {
+            g1_mul(x, x, s);
+        }
+        endStopwatch("g1_mul", start, numIters);
+
+        start = startStopwatch();
+        for (size_t i = 0; i < numIters; i++) {
+            mclBnG1_mul(&xx, &xx, &ss);
+        }
+        endStopwatch("mclBnG1_mul", start, numIters);
+
+        mcl::conv(&t1, &x);
+        REQUIRE(mclBnG1_isEqual(&t1, &xx));
+
+        start = startStopwatch();
+        for (size_t i = 0; i < numIters; i++) {
+            g2_mul(y, y, s);
+        }
+        endStopwatch("g2_mul", start, numIters);
+        start = startStopwatch();
+        for (size_t i = 0; i < numIters; i++) {
+            mclBnG2_mul(&yy, &yy, &ss);
+        }
+        endStopwatch("mclBnG2_mul", start, numIters);
+
+        mcl::conv(&t2, &y);
+        REQUIRE(mclBnG2_isEqual(&t2, &yy));
+
+        gt_t e;
+        gt_new(e);
+        mclBnGT ee;
+        start = startStopwatch();
+        for (size_t i = 0; i < numIters; i++) {
+            pc_map_sim(e, &x, &y, 1);
+        }
+        endStopwatch("pc_map_sim(len=1)", start, numIters);
+        start = startStopwatch();
+        for (size_t i = 0; i < numIters; i++) {
+            mclBn_pairing(&ee, &xx, &yy);
+        }
+        endStopwatch("mclBn_pairing", start, numIters);
+    }
+}
+
+int main(int argc, char* argv[]) {
+    core_init();
+    ep_param_set_any_pairf();
+    mclBn_init(MCL_BLS12_381, MCLBN_COMPILED_TIME_VAR);
+    int result = Catch::Session().run(argc, argv);
+    return result;
+}

--- a/src/threshold.cpp
+++ b/src/threshold.cpp
@@ -93,8 +93,19 @@ InsecureSignature Threshold::SignWithCoefficient(PrivateKey sk, const uint8_t *m
         throw e;
     }
 
+#if 1
+    mclBnFr t1, t2;
+    mclBnG2 s;
+    mcl::conv(&t1, &coeffs[index]);
+    mcl::conv(&t2, sk.keydata);
+    mcl::conv(&s, &sig);
+    mclBnFr_mul(&t1, &t1, &t2);
+    mclBnG2_mul(&s, &s, &t1);
+    mcl::conv(&sig, &s);
+#else
     g2_mul(sig, sig, coeffs[index]);
     g2_mul(sig, sig, *sk.keydata);
+#endif
 
     delete[] coeffs;
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -109,4 +109,72 @@ class Util {
     static SecureFreeCallback secureFreeCallback;
 };
 } // end namespace bls
+
+#include <mcl/bn_c384_256.h>
+#include <assert.h>
+namespace mcl {
+
+inline void byteSwap(uint8_t *buf, size_t n)
+{
+    for (size_t i = 0; i < n/2; i++) {
+        std::swap(buf[i], buf[n - 1 - i]);
+    }
+}
+
+inline void conv(mclBnFr *out, const bn_t *in)
+{
+    assert(in[0]->sign == 0);
+    const int n = in[0]->used;
+    int ret = mclBnFr_setLittleEndianMod(out, in[0]->dp, n * 8);
+    assert(ret == 0);
+}
+
+inline void conv(bn_t *out, const mclBnFr *in)
+{
+    uint8_t buf[256];
+    size_t n = mclBnFr_getLittleEndian(buf, sizeof(buf), in);
+    assert(n > 0);
+    byteSwap(buf, n);
+    bn_read_bin(*out, buf, n);
+}
+
+/*
+    g1_t {
+        fp_st x, y, z;
+        int norm;
+    };
+    fp_st = mclBnFp
+*/
+inline void conv(mclBnG1 *out, const g1_t *in)
+{
+    memcpy(&out->d[MCLBN_FP_UNIT_SIZE * 0], &in[0]->x, MCLBN_FP_UNIT_SIZE * 8);
+    memcpy(&out->d[MCLBN_FP_UNIT_SIZE * 1], &in[0]->y, MCLBN_FP_UNIT_SIZE * 8);
+    memcpy(&out->d[MCLBN_FP_UNIT_SIZE * 2], &in[0]->z, MCLBN_FP_UNIT_SIZE * 8);
+}
+
+inline void conv(g1_t *out, const mclBnG1 *in)
+{
+    memcpy(&out[0]->x, &in->d[MCLBN_FP_UNIT_SIZE * 0], MCLBN_FP_UNIT_SIZE * 8);
+    memcpy(&out[0]->y, &in->d[MCLBN_FP_UNIT_SIZE * 1], MCLBN_FP_UNIT_SIZE * 8);
+    memcpy(&out[0]->z, &in->d[MCLBN_FP_UNIT_SIZE * 2], MCLBN_FP_UNIT_SIZE * 8);
+    out[0]->norm = 0;
+}
+
+inline void conv(mclBnG2 *out, const g2_t *in)
+{
+    memcpy(&out->d[MCLBN_FP_UNIT_SIZE * 0], &in[0]->x, MCLBN_FP_UNIT_SIZE * 8 * 2);
+    memcpy(&out->d[MCLBN_FP_UNIT_SIZE * 2], &in[0]->y, MCLBN_FP_UNIT_SIZE * 8 * 2);
+    memcpy(&out->d[MCLBN_FP_UNIT_SIZE * 4], &in[0]->z, MCLBN_FP_UNIT_SIZE * 8 * 2);
+}
+
+inline void conv(g2_t *out, const mclBnG2 *in)
+{
+    memcpy(&out[0]->x, &in->d[MCLBN_FP_UNIT_SIZE * 0], MCLBN_FP_UNIT_SIZE * 8 * 2);
+    memcpy(&out[0]->y, &in->d[MCLBN_FP_UNIT_SIZE * 2], MCLBN_FP_UNIT_SIZE * 8 * 2);
+    memcpy(&out[0]->z, &in->d[MCLBN_FP_UNIT_SIZE * 4], MCLBN_FP_UNIT_SIZE * 8 * 2);
+    out[0]->norm = 0;
+}
+
+} // mcl
+
 #endif  // SRC_BLSUTIL_HPP_


### PR DESCRIPTION
Hi,
I made a patch to use [mcl](https://github.com/herumi/) for some g1/g2/pairing operations instead of relic.
It gains about 20% speed for Signing and Verification on Intel Core i7-7700.

* Sigining : 1.218 ms (original) -> 0.99 ms (mcl)
* Verification : 2.24 ms (orignal) -> 1.799 ms (mcl)

I'm not good at cmake, so I added src/fp.cpp and src/bn_c384_256.cpp directly but you can link mcl/libmcl.a instead of them.

Could you try it?