### PR TITLE
Wasm port improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist
 python-impl/__pycache__/
 blspy.*.so
 
+js_build
+node_modules
+
 main
 .o
 obj/
@@ -25,6 +28,7 @@ contrib/relic/test/CTestTestfile.cmake
 contrib/gmp-6.1.2/
 contrib/libsodium-1.0.16/
 
+.idea
 .vscode
 blstest
 blstest.*

--- a/js-bindings/CMakeLists.txt
+++ b/js-bindings/CMakeLists.txt
@@ -36,4 +36,4 @@ foreach(file ${JS_BINDINGS_TESTS})
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/${file} tests/${file} COPYONLY)
 endforeach()
 
-set_target_properties(blsjs PROPERTIES LINK_FLAGS "--bind -Oz --llvm-lto 1 --closure 1 -s MODULARIZE_INSTANCE=1")
+set_target_properties(blsjs PROPERTIES LINK_FLAGS "--bind -Oz --closure 1 -s MODULARIZE=1")

--- a/js-bindings/CMakeLists.txt
+++ b/js-bindings/CMakeLists.txt
@@ -36,4 +36,4 @@ foreach(file ${JS_BINDINGS_TESTS})
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/${file} tests/${file} COPYONLY)
 endforeach()
 
-set_target_properties(blsjs PROPERTIES LINK_FLAGS "--bind -s SINGLE_FILE=1 -s MODULARIZE_INSTANCE=1 -s BINARYEN_ASYNC_COMPILATION=0")
+set_target_properties(blsjs PROPERTIES LINK_FLAGS "--bind -s MODULARIZE_INSTANCE=1")

--- a/js-bindings/CMakeLists.txt
+++ b/js-bindings/CMakeLists.txt
@@ -36,4 +36,4 @@ foreach(file ${JS_BINDINGS_TESTS})
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/${file} tests/${file} COPYONLY)
 endforeach()
 
-set_target_properties(blsjs PROPERTIES LINK_FLAGS "--bind -s MODULARIZE_INSTANCE=1")
+set_target_properties(blsjs PROPERTIES LINK_FLAGS "--bind -Oz --llvm-lto 1 --closure 1 -s MODULARIZE_INSTANCE=1")

--- a/js-bindings/README.md
+++ b/js-bindings/README.md
@@ -10,17 +10,21 @@ This library is a JavaScript port of the [Chia Network's BLS lib](https://github
 npm i bls-signatures --save
 ```
 ```javascript
-const { PrivateKey } = require('bls-signatures');
-const privateKey = PrivateKey.fromSeed(Uint8Array.from([1,2,3]));
-const sig = privateKey.sign(Uint8Array.from(Buffer.from("Hello world!")));
-const isValidSignature = sig.verify();
-
-if (isValidSignature) {
-    // Do stuff...
-}
-
-privateKey.delete();
-sig.delete();
+const blsSignatures = require('bls-signatures')();
+blsSignatures.then(() => {
+    // Instance is loaded and ready to be used
+    const { PrivateKey } = blsSignatures;
+    const privateKey = PrivateKey.fromSeed(Uint8Array.from([1,2,3]));
+    const sig = privateKey.sign(Uint8Array.from(Buffer.from("Hello world!")));
+    const isValidSignature = sig.verify();
+    
+    if (isValidSignature) {
+        // Do stuff...
+    }
+    
+    privateKey.delete();
+    sig.delete();
+})
 ```
 
 Please refer to the library's [typings](../../js-bindings/blsjs.d.ts) for detailed API information. Use cases can be found in the [original lib's readme](../../README.md).

--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -1,4 +1,4 @@
-export class PrivateKey {
+declare class PrivateKey {
     static PRIVATE_KEY_SIZE: number;
 
     static fromSeed(seed: Uint8Array): PrivateKey;
@@ -22,7 +22,7 @@ export class PrivateKey {
     delete(): void;
 }
 
-export class InsecureSignature {
+declare class InsecureSignature {
     static SIGNATURE_SIZE: number;
 
     static fromBytes(bytes: Uint8Array);
@@ -38,7 +38,7 @@ export class InsecureSignature {
     delete(): void;
 }
 
-export class Signature {
+declare class Signature {
     static SIGNATURE_SIZE: number;
 
     static fromBytes(bytes: Uint8Array): Signature;
@@ -58,7 +58,7 @@ export class Signature {
     delete(): void;
 }
 
-export class PublicKey {
+declare class PublicKey {
     static PUBLIC_KEY_SIZE: number;
 
     static fromBytes(bytes: Uint8Array): PublicKey;
@@ -74,7 +74,7 @@ export class PublicKey {
     delete(): void;
 }
 
-export class AggregationInfo {
+declare class AggregationInfo {
     static fromMsgHash(publicKey: PublicKey, messageHash: Uint8Array): AggregationInfo;
 
     static fromMsg(publicKey: PublicKey, message: Uint8Array): AggregationInfo;
@@ -90,7 +90,7 @@ export class AggregationInfo {
     delete(): void;
 }
 
-export class ExtendedPrivateKey {
+declare class ExtendedPrivateKey {
     static EXTENDED_PRIVATE_KEY_SIZE: number;
 
     static fromSeed(seed: Uint8Array): ExtendedPrivateKey;
@@ -122,7 +122,7 @@ export class ExtendedPrivateKey {
     delete(): void;
 }
 
-export class ExtendedPublicKey {
+declare class ExtendedPublicKey {
     static VERSION: number;
     static EXTENDED_PUBLIC_KEY_SIZE: number;
 
@@ -147,7 +147,7 @@ export class ExtendedPublicKey {
     delete(): void;
 }
 
-export class ChainCode {
+declare class ChainCode {
     static CHAIN_CODE_SIZE: number;
 
     static fromBytes(bytes: Uint8Array);
@@ -157,16 +157,31 @@ export class ChainCode {
     delete(): void;
 }
 
-export namespace Threshold {
-    export function create(commitment: PublicKey[], secretFragments: PrivateKey[], threshold: number, playersCount: number): PrivateKey;
+declare class Threshold {
+    static create(commitment: PublicKey[], secretFragments: PrivateKey[], threshold: number, playersCount: number): PrivateKey;
 
-    export function signWithCoefficient(sk: PrivateKey, message: Uint8Array, playerIndex: number, players: number[]): InsecureSignature;
+    static signWithCoefficient(sk: PrivateKey, message: Uint8Array, playerIndex: number, players: number[]): InsecureSignature;
 
-    export function aggregateUnitSigs(signatures: InsecureSignature[], message: Uint8Array, players: number[]): InsecureSignature;
+    static aggregateUnitSigs(signatures: InsecureSignature[], message: Uint8Array, players: number[]): InsecureSignature;
 
-    export function verifySecretFragment(playerIndex: number, secretFragment: PrivateKey, commitment: PublicKey[], threshold: number): boolean;
+    static verifySecretFragment(playerIndex: number, secretFragment: PrivateKey, commitment: PublicKey[], threshold: number): boolean;
 }
 
-export function DHKeyExchange(privateKey: PrivateKey, publicKey: PublicKey);
+interface ModuleInstance {
+    then: (callback: (moduleInstance: ModuleInstance) => any) => ModuleInstance;
+    PrivateKey: typeof PrivateKey;
+    InsecureSignature: typeof InsecureSignature;
+    Signature: typeof Signature;
+    PublicKey: typeof PublicKey;
+    AggregationInfo: typeof AggregationInfo;
+    ExtendedPrivateKey: typeof ExtendedPrivateKey;
+    ExtendedPublicKey: typeof ExtendedPublicKey;
+    ChainCode: typeof ChainCode;
+    Threshold: typeof Threshold;
+    DHKeyExchange(privateKey: PrivateKey, publicKey: PublicKey);
+    GROUP_ORDER: string;
+}
 
-export const GROUP_ORDER: string;
+declare function createModule(options?: {}): ModuleInstance;
+
+export = createModule;

--- a/js-bindings/package-lock.json
+++ b/js-bindings/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-signatures",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2040,7 +2040,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2061,12 +2062,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2081,17 +2084,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2208,7 +2214,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2220,6 +2227,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2234,6 +2242,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2241,12 +2250,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2265,6 +2276,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2345,7 +2357,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2357,6 +2370,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2442,7 +2456,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2478,6 +2493,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2497,6 +2513,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2540,12 +2557,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4949,9 +4968,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
       "dev": true
     },
     "ultron": {

--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -22,7 +22,7 @@
     "type": "git",
     "url": "git@github.com:Chia-Network/bls-signatures.git"
   },
-  "homepage" : "https://github.com/Chia-Network/bls-signatures/tree/master/js-bindings",
+  "homepage": "https://github.com/Chia-Network/bls-signatures/tree/master/js-bindings",
   "author": {
     "name": "Anton Suprunchuk",
     "email": "antouhou@gmail.com",
@@ -44,7 +44,7 @@
     "karma-mocha": "^1.3.0",
     "karma-webpack": "^3.0.5",
     "mocha": "6.0.2",
-    "typescript": "^3.3.3333",
+    "typescript": "^3.6.2",
     "webpack": "^4.29.6"
   }
 }

--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,8 +1,14 @@
 {
   "name": "bls-signatures",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "The most advanced BLS library for JavaScript",
   "main": "blsjs.js",
+  "types": "blsjs.d.ts",
+  "files": [
+    "blsjs.js",
+    "blsjs.wasm",
+    "blsjs.d.ts"
+  ],
   "directories": {
     "test": "tests"
   },
@@ -12,7 +18,11 @@
     "test:node": "npm run test:typings && mocha ./tests/*.spec.js",
     "test:browser": "npm run test:typings && karma start ./tests/karma.conf.js --single-run"
   },
-  "repository": "https://github.com/antouhou/bls-signatures/tree/feature/js_build/js-bindings",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Chia-Network/bls-signatures.git"
+  },
+  "homepage" : "https://github.com/Chia-Network/bls-signatures/tree/master/js-bindings",
   "author": {
     "name": "Anton Suprunchuk",
     "email": "antouhou@gmail.com",
@@ -26,8 +36,6 @@
     "crypto",
     "cryptography"
   ],
-  "dependencies": {},
-  "types": "blsjs.d.ts",
   "devDependencies": {
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.11.0",

--- a/js-bindings/tests/AggregationInfo.spec.js
+++ b/js-bindings/tests/AggregationInfo.spec.js
@@ -1,4 +1,4 @@
-const {AggregationInfo, PrivateKey} = require('../');
+const blsSignatures = require('..')();
 const assert = require('assert');
 const crypto = require('crypto');
 
@@ -6,8 +6,16 @@ function getSeed() {
     return Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 }
 
+before((done) => {
+    blsSignatures.then(() => {
+        done();
+    });
+});
+
 describe('AggregationInfo', () => {
     it('Should be able to serialize and deserialize data correctly', () => {
+        const {AggregationInfo, PrivateKey} = blsSignatures;
+
         const privateKey = PrivateKey.fromSeed(getSeed());
         const message = Uint8Array.from(Buffer.from('Hello world', 'utf8'));
         const sig = privateKey.sign(message);

--- a/js-bindings/tests/ChainCode.spec.js
+++ b/js-bindings/tests/ChainCode.spec.js
@@ -1,5 +1,5 @@
+const blsSignatures = require('..')();
 const assert = require('assert');
-const {ChainCode} = require('../');
 
 function getChainCodeHex() {
     return '9728accd39f28f05077f224440e7f1781684e22855de41170ef2af0b75022083';
@@ -9,8 +9,16 @@ function getChainCodeBytes() {
     return Uint8Array.from(Buffer.from(getChainCodeHex(), 'hex'));
 }
 
+before((done) => {
+    blsSignatures.then(() => {
+        done();
+    });
+});
+
 describe('ChainCode', () => {
     it('Should create chain code from a buffer and serialize to the same buffer', () => {
+        const {ChainCode} = blsSignatures;
+
         const chainCode = ChainCode.fromBytes(getChainCodeBytes());
         assert(chainCode instanceof ChainCode);
         const serialized = chainCode.serialize();

--- a/js-bindings/tests/ExtendedPrivateKey.spec.js
+++ b/js-bindings/tests/ExtendedPrivateKey.spec.js
@@ -1,12 +1,20 @@
+const blsSignatures = require('..')();
 const assert = require('assert');
-const {ExtendedPrivateKey} = require('../');
 
 function getSeed() {
     return Uint8Array.from([1, 50, 6, 244, 24, 199, 1, 25]);
 }
 
+before((done) => {
+    blsSignatures.then(() => {
+        done();
+    });
+});
+
 describe('ExtendedPrivateKey', () => {
     it('Should derive correctly', () => {
+        const {ExtendedPrivateKey} = blsSignatures;
+
         const seed = getSeed();
         const esk = ExtendedPrivateKey.fromSeed(seed);
         assert.strictEqual(esk.getPublicKey().getFingerprint(), 0xa4700b27);

--- a/js-bindings/tests/ExtendedPublicKey.spec.js
+++ b/js-bindings/tests/ExtendedPublicKey.spec.js
@@ -1,8 +1,16 @@
+const blsSignatures = require('..')();
 const assert = require('assert');
-const {ExtendedPublicKey, ExtendedPrivateKey} = require('../');
+
+before((done) => {
+    blsSignatures.then(() => {
+        done();
+    });
+});
 
 describe('ExtendedPublicKey', () => {
     it('Should return correct data structures', () => {
+        const {ExtendedPrivateKey} = blsSignatures;
+
         const seed = Uint8Array.from([1, 50, 6, 244, 24, 199, 1, 0, 0, 0]);
         const esk = ExtendedPrivateKey.fromSeed(seed);
         const epk = esk.getExtendedPublicKey();

--- a/js-bindings/tests/PrivateKey.spec.js
+++ b/js-bindings/tests/PrivateKey.spec.js
@@ -1,4 +1,4 @@
-const {PrivateKey, Signature, PublicKey, AggregationInfo} = require('../');
+const blsSignatures = require('..')();
 const assert = require('assert');
 const crypto = require('crypto');
 
@@ -27,8 +27,16 @@ function getPkUint8Array() {
     return new Uint8Array(getPkBuffer());
 }
 
+before((done) => {
+    blsSignatures.then(() => {
+        done();
+    });
+});
+
 describe('PrivateKey', () => {
     it('Should sign and verify', () => {
+        const {PrivateKey, AggregationInfo} = blsSignatures;
+
         const message1 = Uint8Array.from([1, 65, 254, 88, 90, 45, 22]);
 
         const seed = Uint8Array.from([28, 20, 102, 229, 1, 157]);
@@ -51,6 +59,8 @@ describe('PrivateKey', () => {
 
     describe('.fromSeed', () => {
         it('Should create a private key from a seed', () => {
+            const {PrivateKey} = blsSignatures;
+
             const pk = PrivateKey.fromSeed(getPkSeed());
             assert(pk instanceof PrivateKey);
             assert.deepStrictEqual(pk.serialize(), getPkBuffer());
@@ -58,11 +68,15 @@ describe('PrivateKey', () => {
     });
     describe('.fromBytes', () => {
         it('Should create a private key from a Buffer', () => {
+            const {PrivateKey} = blsSignatures;
+
             const pk = PrivateKey.fromBytes(getPkBuffer(), false);
             assert(pk instanceof PrivateKey);
             assert.deepStrictEqual(pk.serialize(), getPkBuffer());
         });
         it('Should create a private key from a Uint8Array', () => {
+            const {PrivateKey} = blsSignatures;
+
             const pk = PrivateKey.fromBytes(getPkUint8Array(), false);
             assert(pk instanceof PrivateKey);
             assert.deepStrictEqual(pk.serialize(), getPkBuffer());
@@ -71,6 +85,8 @@ describe('PrivateKey', () => {
 
     describe('.aggregate', () => {
         it('Should aggregate private keys', () => {
+            const {PrivateKey} = blsSignatures;
+
             const privateKeys = [
                 PrivateKey.fromSeed(Buffer.from([1, 2, 3])),
                 PrivateKey.fromSeed(Buffer.from([3, 4, 5]))
@@ -86,6 +102,8 @@ describe('PrivateKey', () => {
 
     describe('#serialize', () => {
         it('Should serialize key to a Buffer', () => {
+            const {PrivateKey} = blsSignatures;
+
             const pk = PrivateKey.fromSeed(getPkSeed());
             const serialized = pk.serialize();
             assert(serialized instanceof Uint8Array);
@@ -95,6 +113,8 @@ describe('PrivateKey', () => {
 
     describe('#sign', () => {
         it('Should return a verifiable signature', () => {
+            const {PrivateKey, Signature} = blsSignatures;
+
             const pk = PrivateKey.fromBytes(getPkBuffer(), false);
             const message = 'Hello world';
             const signature = pk.sign(Uint8Array.from(Buffer.from(message, 'utf8')));
@@ -105,6 +125,8 @@ describe('PrivateKey', () => {
 
     describe('#signPrehashed', () => {
         it('Should sign a hash and return a signature', () => {
+            const {PrivateKey, Signature} = blsSignatures;
+
             const pk = PrivateKey.fromSeed(Uint8Array.from([1, 2, 3, 4, 5]));
             const messageHash = Uint8Array.from(crypto
                 .createHash('sha256')
@@ -120,6 +142,8 @@ describe('PrivateKey', () => {
 
     describe('#getPublicKey', () => {
         it('Should return a public key with a verifiable fingerprint', () => {
+            const {PrivateKey, PublicKey} = blsSignatures;
+
             const pk = PrivateKey.fromSeed(getSeedAndFinferprint().seed);
             const publicKey = pk.getPublicKey();
             assert(publicKey instanceof PublicKey);

--- a/js-bindings/tests/PublicKey.spec.js
+++ b/js-bindings/tests/PublicKey.spec.js
@@ -1,6 +1,5 @@
+const blsSignatures = require('..')();
 const assert = require('assert');
-
-const {PublicKey, PrivateKey} = require('../');
 
 function getPublicKeyFixtureHex() {
     return '1790635de8740e9a6a6b15fb6b72f3a16afa0973d971979b6ba54761d6e2502c50db76f4d26143f05459a42cfd520d44';
@@ -26,9 +25,17 @@ function getPublicKeysArray() {
     })
 }
 
+before((done) => {
+    blsSignatures.then(() => {
+        done();
+    });
+});
+
 describe('PublicKey', () => {
     describe('.fromBytes', () => {
         it('Should create a public key from bytes', () => {
+            const {PublicKey} = blsSignatures;
+
             const pk = PublicKey.fromBytes(getPublicKeyFixture().buffer);
             assert(pk instanceof PublicKey);
         });
@@ -36,6 +43,8 @@ describe('PublicKey', () => {
 
     describe('.aggregate', () => {
         it('Should aggregate keys if keys array contains more than one key', () => {
+            const {PublicKey} = blsSignatures;
+
             const pks = getPublicKeysArray().map(buf => PublicKey.fromBytes(buf));
             const aggregatedKey = PublicKey.aggregate(pks);
             assert(aggregatedKey instanceof PublicKey);
@@ -44,6 +53,8 @@ describe('PublicKey', () => {
 
     describe('#serialize', () => {
         it('Should serialize key to the same buffer', () => {
+            const {PublicKey} = blsSignatures;
+
             const pk = PublicKey.fromBytes(getPublicKeyFixture().buffer);
             const serialized = pk.serialize();
             assert.deepStrictEqual(Buffer.from(serialized).toString('hex'), getPublicKeyFixtureHex());
@@ -52,6 +63,8 @@ describe('PublicKey', () => {
 
     describe('getFingerprint', () => {
         it('Should get correct fingerprint', () => {
+            const {PublicKey} = blsSignatures;
+
             const pk = PublicKey.fromBytes(getPublicKeyFixture().buffer);
             const fingerprint = pk.getFingerprint();
             assert.strictEqual(fingerprint, getPublicKeyFixture().fingerprint);

--- a/js-bindings/tests/Signature.spec.js
+++ b/js-bindings/tests/Signature.spec.js
@@ -1,6 +1,6 @@
+const blsSignatures = require('..')();
 const assert = require('assert');
 const {createHash} = require('crypto');
-const {Signature, InsecureSignature, PublicKey, PrivateKey, AggregationInfo} = require('../');
 
 function getSignatureHex() {
     return '006d0a8661db762a94be51be85efb1199f62dfc3f8fa8c9f003d02fdc69b281e689a54928b9adce98a8471a889c55af40c9bd7b7339c00f6f8bf871d132cfa5cf4e9b11f7ce05acafbb24c2db82b7f6193ee954f5167a2a46e3daecf4a007609';
@@ -18,9 +18,17 @@ function getAggregationInfo() {
     };
 }
 
+before((done) => {
+    blsSignatures.then(() => {
+        done();
+    });
+});
+
 describe('Signature', () => {
     describe('Integration', () => {
         it('Should verify signatures', function () {
+            const {Signature, PublicKey, PrivateKey, AggregationInfo} = blsSignatures;
+
             this.timeout(10000);
             const message = Uint8Array.from([100, 2, 254, 88, 90, 45, 23]);
             const seed1 = Uint8Array.from([1, 2, 3, 4, 5]);
@@ -66,6 +74,8 @@ describe('Signature', () => {
     });
     describe('.fromBytes', () => {
         it('Should create verifiable signature from bytes', () => {
+            const {Signature} = blsSignatures;
+
             const sig = Signature.fromBytes(getSignatureBytes());
             assert.strictEqual(Buffer.from(sig.serialize()).toString('hex'), getSignatureHex());
             // Since there is no aggregation info, it's impossible to verify sig
@@ -76,6 +86,8 @@ describe('Signature', () => {
     });
     describe('.fromBytesAndAggregationInfo', () => {
         it('Should create verifiable signature', () => {
+            const {Signature, PrivateKey} = blsSignatures;
+
             const pk = PrivateKey.fromSeed(Uint8Array.from([1, 2, 3, 4, 5]));
             const sig = pk.sign(Uint8Array.from([100, 2, 254, 88, 90, 45, 23]));
             const info = sig.getAggregationInfo();
@@ -99,6 +111,8 @@ describe('Signature', () => {
     });
     describe('.aggregateSigs', () => {
         it('Should aggregate signature', () => {
+            const {Signature, PrivateKey} = blsSignatures;
+
             const sk = PrivateKey.fromSeed(Uint8Array.from([1, 2, 3]));
             const sig1 = sk.sign(Uint8Array.from([3, 4, 5]));
             const sig2 = sk.sign(Uint8Array.from([6, 7, 8]));
@@ -113,6 +127,8 @@ describe('Signature', () => {
     });
     describe('#serialize', () => {
         it('Should serialize signature to Buffer', () => {
+            const {Signature, PrivateKey} = blsSignatures;
+
             const pk = PrivateKey.fromSeed(Uint8Array.from([1, 2, 3, 4, 5]));
             const sig = pk.sign(Uint8Array.from([100, 2, 254, 88, 90, 45, 23]));
             assert(sig instanceof Signature);
@@ -124,6 +140,8 @@ describe('Signature', () => {
     });
     describe('#verify', () => {
         it('Should return true if signature can be verified', () => {
+            const {Signature, PublicKey, AggregationInfo} = blsSignatures;
+
             const pks = getAggregationInfo().publicKeys.map(buf => PublicKey.fromBytes(buf));
             const sig = Signature.fromBytesAndAggregationInfo(
                 getSignatureBytes(),
@@ -138,6 +156,8 @@ describe('Signature', () => {
             sig.delete();
         });
         it("Should return false if signature can't be verified", () => {
+            const {PublicKey, PrivateKey, AggregationInfo} = blsSignatures;
+
             const sk = PrivateKey.fromSeed(Buffer.from([1, 2, 3, 4, 5]));
             const pks = getAggregationInfo().publicKeys.map(buf => PublicKey.fromBytes(buf));
             const sig = sk.sign(Uint8Array.from(Buffer.from('Message')));
@@ -159,6 +179,8 @@ describe('Signature', () => {
 describe('InsecureSignature', () => {
     describe('.fromBytes', () => {
         it('Should create sig from bytes', () => {
+            const {InsecureSignature} = blsSignatures;
+
             const sig = InsecureSignature.fromBytes(getSignatureBytes());
             assert(sig instanceof InsecureSignature);
 
@@ -167,6 +189,8 @@ describe('InsecureSignature', () => {
     });
     describe('.aggregate', () => {
         it('Should aggregate signature', () => {
+            const {InsecureSignature, PrivateKey} = blsSignatures;
+
             const sk = PrivateKey.fromSeed(Uint8Array.from([1, 2, 3]));
             const msg1 = Uint8Array.from([3, 4, 5]);
             const msg2 = Uint8Array.from([6, 7, 8]);
@@ -188,6 +212,8 @@ describe('InsecureSignature', () => {
     });
     describe('#verify', () => {
         it('Should return true if signature can be verified', () => {
+            const {InsecureSignature, PublicKey} = blsSignatures;
+
             const sig = InsecureSignature.fromBytes(getSignatureBytes());
             const messageHashes = getAggregationInfo().messageHashes;
             const pubKeys = getAggregationInfo().publicKeys.map(buf => PublicKey.fromBytes(buf));
@@ -196,6 +222,8 @@ describe('InsecureSignature', () => {
             sig.delete();
         });
         it("Should return false if signature can't be verified", () => {
+            const {InsecureSignature, PrivateKey} = blsSignatures;
+
             const sig = InsecureSignature.fromBytes(getSignatureBytes());
             const messageHashes = getAggregationInfo().messageHashes;
             const pubKeys = [PrivateKey.fromSeed(Uint8Array.from([6, 7, 8])).getPublicKey()];
@@ -204,6 +232,8 @@ describe('InsecureSignature', () => {
     });
     describe('#divideBy', () => {
         it('Should divide signature', () => {
+            const {InsecureSignature, PrivateKey} = blsSignatures;
+
             const sk = PrivateKey.fromSeed(Uint8Array.from([1, 2, 3]));
             const msg1 = Uint8Array.from([3, 4, 5]);
             const msg2 = Uint8Array.from([6, 7, 8]);
@@ -227,6 +257,8 @@ describe('InsecureSignature', () => {
     });
     describe('#serialize', () => {
         it('Should serialize the sig', () => {
+            const {InsecureSignature} = blsSignatures;
+
             const sig = InsecureSignature.fromBytes(getSignatureBytes());
             assert(sig instanceof InsecureSignature);
             assert.strictEqual(Buffer.from(sig.serialize()).toString('hex'), getSignatureHex());

--- a/js-bindings/tests/Threshold.spec.js
+++ b/js-bindings/tests/Threshold.spec.js
@@ -1,9 +1,17 @@
+const blsSignatures = require('..')();
 const assert = require('assert');
-const {Threshold, PublicKey, PrivateKey, InsecureSignature} = require('../');
 const crypto = require('crypto');
+
+before((done) => {
+    blsSignatures.then(() => {
+        done();
+    });
+});
 
 describe('Threshold', () => {
     it('Should be able to verify secret fragment', function () {
+        const {Threshold, PublicKey, PrivateKey, InsecureSignature} = blsSignatures;
+
         this.timeout(10000);
         // To initialize a T of N threshold key under a
         // Joint-Feldman scheme:

--- a/js-bindings/tests/typings.spec.ts
+++ b/js-bindings/tests/typings.spec.ts
@@ -1,214 +1,218 @@
 // This file is used to check if the typescript typings are working
-import {
-    AggregationInfo,
-    ChainCode,
-    ExtendedPrivateKey,
-    ExtendedPublicKey,
-    GROUP_ORDER,
-    InsecureSignature,
-    PrivateKey,
-    PublicKey,
-    Signature,
-    Threshold,
-    DHKeyExchange
-} from '../';
+import createBlsSignaturesModule = require('..');
 import {deepStrictEqual, ok, strictEqual} from 'assert';
 import {createHash} from 'crypto';
 
-function getSkSeed(): Uint8Array {
-    return Uint8Array.from([1, 2, 3]);
-}
+const blsSignatures = createBlsSignaturesModule().then(() => {
+    const {
+        AggregationInfo,
+        ChainCode,
+        ExtendedPrivateKey,
+        ExtendedPublicKey,
+        GROUP_ORDER,
+        InsecureSignature,
+        PrivateKey,
+        PublicKey,
+        Signature,
+        Threshold,
+        DHKeyExchange
+    } = blsSignatures;
 
-function getSkBytes(): Uint8Array {
-    return Uint8Array.from([17, 124, 119, 158, 68, 227, 109, 63, 132, 68, 94, 198, 126, 236, 73, 71, 11, 7, 137, 235, 99, 63, 16, 34, 9, 175, 110, 14, 189, 156, 27, 249]);
-}
+    function getSkSeed(): Uint8Array {
+        return Uint8Array.from([1, 2, 3]);
+    }
 
-function getPkBytes(): Uint8Array {
-    return Uint8Array.from([15, 128, 94, 226, 6, 236, 252, 3, 126, 41, 152, 204, 169, 80, 66, 245, 222, 64, 241, 191, 28, 142, 160, 62, 49, 244, 132, 97, 169, 171, 155, 96, 74, 253, 238, 108, 207, 75, 69, 38, 180, 24, 158, 26, 205, 241, 96, 236]);
-}
+    function getSkBytes(): Uint8Array {
+        return Uint8Array.from([17, 124, 119, 158, 68, 227, 109, 63, 132, 68, 94, 198, 126, 236, 73, 71, 11, 7, 137, 235, 99, 63, 16, 34, 9, 175, 110, 14, 189, 156, 27, 249]);
+    }
 
-function getMessageBytes(): Uint8Array {
-    return Uint8Array.from([1, 2, 3]);
-}
+    function getPkBytes(): Uint8Array {
+        return Uint8Array.from([15, 128, 94, 226, 6, 236, 252, 3, 126, 41, 152, 204, 169, 80, 66, 245, 222, 64, 241, 191, 28, 142, 160, 62, 49, 244, 132, 97, 169, 171, 155, 96, 74, 253, 238, 108, 207, 75, 69, 38, 180, 24, 158, 26, 205, 241, 96, 236]);
+    }
 
-function getMessageHash(): Uint8Array {
-    return Uint8Array.from(createHash('sha256').update(getMessageBytes()).digest());
-}
+    function getMessageBytes(): Uint8Array {
+        return Uint8Array.from([1, 2, 3]);
+    }
 
-function getSignatureBytes(): Uint8Array {
-    return Uint8Array.from([131, 187, 59, 142, 42, 69, 254, 152, 172, 85, 1, 103, 4, 107, 65, 193, 195, 175, 119, 132, 122, 179, 123, 253, 215, 68, 17, 175, 180, 243, 5, 84, 167, 202, 236, 130, 219, 226, 72, 63, 235, 94, 225, 180, 148, 103, 109, 90, 24, 188, 105, 125, 165, 74, 188, 127, 250, 160, 207, 30, 196, 106, 168, 62, 79, 168, 219, 76, 43, 87, 167, 252, 69, 187, 113, 173, 182, 0, 137, 145, 4, 131, 190, 251, 181, 23, 82, 188, 87, 127, 242, 46, 234, 237, 220, 9]);
-}
+    function getMessageHash(): Uint8Array {
+        return Uint8Array.from(createHash('sha256').update(getMessageBytes()).digest());
+    }
 
-function getEskBytes(): Uint8Array {
-    return Uint8Array.from([0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 137, 75, 79, 148, 193, 235, 158, 172, 163, 41, 102, 134, 72, 161, 187, 104, 97, 202, 38, 27, 206, 125, 64, 60, 149, 248, 29, 53, 180, 23, 253, 255, 81, 166, 177, 172, 207, 58, 74, 10, 229, 43, 174, 77, 91, 222, 159, 24, 29, 11, 190, 149, 27, 94, 76, 12, 100, 94, 17, 220, 38, 66, 179, 28]);
-}
+    function getSignatureBytes(): Uint8Array {
+        return Uint8Array.from([131, 187, 59, 142, 42, 69, 254, 152, 172, 85, 1, 103, 4, 107, 65, 193, 195, 175, 119, 132, 122, 179, 123, 253, 215, 68, 17, 175, 180, 243, 5, 84, 167, 202, 236, 130, 219, 226, 72, 63, 235, 94, 225, 180, 148, 103, 109, 90, 24, 188, 105, 125, 165, 74, 188, 127, 250, 160, 207, 30, 196, 106, 168, 62, 79, 168, 219, 76, 43, 87, 167, 252, 69, 187, 113, 173, 182, 0, 137, 145, 4, 131, 190, 251, 181, 23, 82, 188, 87, 127, 242, 46, 234, 237, 220, 9]);
+    }
 
-function getEpkBytes(): Uint8Array {
-    return Uint8Array.from([0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 137, 75, 79, 148, 193, 235, 158, 172, 163, 41, 102, 134, 72, 161, 187, 104, 97, 202, 38, 27, 206, 125, 64, 60, 149, 248, 29, 53, 180, 23, 253, 255, 24, 98, 251, 112, 141, 167, 192, 161, 112, 151, 212, 18, 81, 160, 252, 201, 123, 120, 210, 54, 179, 74, 108, 219, 124, 123, 134, 186, 135, 75, 153, 183, 255, 54, 167, 17, 156, 63, 152, 194, 167, 30, 154, 29, 70, 218, 114, 53]);
-}
+    function getEskBytes(): Uint8Array {
+        return Uint8Array.from([0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 137, 75, 79, 148, 193, 235, 158, 172, 163, 41, 102, 134, 72, 161, 187, 104, 97, 202, 38, 27, 206, 125, 64, 60, 149, 248, 29, 53, 180, 23, 253, 255, 81, 166, 177, 172, 207, 58, 74, 10, 229, 43, 174, 77, 91, 222, 159, 24, 29, 11, 190, 149, 27, 94, 76, 12, 100, 94, 17, 220, 38, 66, 179, 28]);
+    }
 
-function getChainCodeBytes(): Uint8Array {
-    return Uint8Array.from([137, 75, 79, 148, 193, 235, 158, 172, 163, 41, 102, 134, 72, 161, 187, 104, 97, 202, 38, 27, 206, 125, 64, 60, 149, 248, 29, 53, 180, 23, 253, 255]);
-}
+    function getEpkBytes(): Uint8Array {
+        return Uint8Array.from([0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 137, 75, 79, 148, 193, 235, 158, 172, 163, 41, 102, 134, 72, 161, 187, 104, 97, 202, 38, 27, 206, 125, 64, 60, 149, 248, 29, 53, 180, 23, 253, 255, 24, 98, 251, 112, 141, 167, 192, 161, 112, 151, 212, 18, 81, 160, 252, 201, 123, 120, 210, 54, 179, 74, 108, 219, 124, 123, 134, 186, 135, 75, 153, 183, 255, 54, 167, 17, 156, 63, 152, 194, 167, 30, 154, 29, 70, 218, 114, 53]);
+    }
 
-describe('typings', () => {
-    it('PrivateKey', () => {
-        strictEqual(PrivateKey.PRIVATE_KEY_SIZE, 32);
-        const sk: PrivateKey = PrivateKey.fromSeed(getSkSeed());
-        const sk2: PrivateKey = PrivateKey.fromBytes(getSkBytes(), false);
-        const aggSk: PrivateKey = PrivateKey.aggregate([sk], [sk.getPublicKey()]);
-        const aggSk2: PrivateKey = PrivateKey.aggregateInsecure([sk]);
-        const pk: PublicKey = sk.getPublicKey();
-        const bytes: Uint8Array = sk.serialize();
-        const sig: Signature = sk.sign(getMessageBytes());
-        const insecureSig: InsecureSignature = sk.signInsecure(getMessageBytes());
-        const prehashedSig: Signature = sk.signPrehashed(getMessageHash());
-        ok(sig.verify());
-        sk.delete();
-        sk2.delete();
-        aggSk.delete();
-        aggSk2.delete();
-        pk.delete();
-        sig.delete();
-        insecureSig.delete();
-        prehashedSig.delete();
-    });
+    function getChainCodeBytes(): Uint8Array {
+        return Uint8Array.from([137, 75, 79, 148, 193, 235, 158, 172, 163, 41, 102, 134, 72, 161, 187, 104, 97, 202, 38, 27, 206, 125, 64, 60, 149, 248, 29, 53, 180, 23, 253, 255]);
+    }
 
-    it('InsecureSignature', () => {
-        strictEqual(InsecureSignature.SIGNATURE_SIZE, 96);
-        const sig: InsecureSignature = InsecureSignature.fromBytes(getSignatureBytes());
-        const aggSig: InsecureSignature = InsecureSignature.aggregate([sig]);
-        const isValid: boolean = sig.verify([getMessageHash()], [PublicKey.fromBytes(getPkBytes())]);
-        const serialized: Uint8Array = sig.serialize();
-        ok(isValid);
-        sig.delete();
-        aggSig.delete();
-    });
+    describe('typings', () => {
+        it('PrivateKey', () => {
+            strictEqual(PrivateKey.PRIVATE_KEY_SIZE, 32);
+            const sk = PrivateKey.fromSeed(getSkSeed());
+            const sk2 = PrivateKey.fromBytes(getSkBytes(), false);
+            const aggSk = PrivateKey.aggregate([sk], [sk.getPublicKey()]);
+            const aggSk2 = PrivateKey.aggregateInsecure([sk]);
+            const pk = sk.getPublicKey();
+            const bytes: Uint8Array = sk.serialize();
+            const sig = sk.sign(getMessageBytes());
+            const insecureSig = sk.signInsecure(getMessageBytes());
+            const prehashedSig = sk.signPrehashed(getMessageHash());
+            ok(sig.verify());
+            sk.delete();
+            sk2.delete();
+            aggSk.delete();
+            aggSk2.delete();
+            pk.delete();
+            sig.delete();
+            insecureSig.delete();
+            prehashedSig.delete();
+        });
 
-    it('Signature', () => {
-        strictEqual(Signature.SIGNATURE_SIZE, 96);
-        const info = AggregationInfo.fromMsg(PublicKey.fromBytes(getPkBytes()), getMessageBytes());
-        const sig: Signature = Signature.fromBytesAndAggregationInfo(getSignatureBytes(), info);
-        const aggSig: Signature = Signature.aggregateSigs([sig]);
-        const sig2: Signature = Signature.fromBytes(getSignatureBytes());
-        const isValid: boolean = sig.verify();
-        const serialized: Uint8Array = sig.serialize();
-        const aggInfo: AggregationInfo = sig.getAggregationInfo();
-        ok(isValid);
-        sig.setAggregationInfo(info);
-        sig.delete();
-        aggSig.delete();
-        sig2.delete();
-        aggInfo.delete();
-    });
+        it('InsecureSignature', () => {
+            strictEqual(InsecureSignature.SIGNATURE_SIZE, 96);
+            const sig = InsecureSignature.fromBytes(getSignatureBytes());
+            const aggSig = InsecureSignature.aggregate([sig]);
+            const isValid: boolean = sig.verify([getMessageHash()], [PublicKey.fromBytes(getPkBytes())]);
+            const serialized: Uint8Array = sig.serialize();
+            ok(isValid);
+            sig.delete();
+            aggSig.delete();
+        });
 
-    it('PublicKey', () => {
-        strictEqual(PublicKey.PUBLIC_KEY_SIZE, 48);
-        const pk: PublicKey = PublicKey.fromBytes(getPkBytes());
-        const aggPk: PublicKey = PublicKey.aggregate([pk]);
-        const aggPk2: PublicKey = PublicKey.aggregateInsecure([pk]);
-        const fingerprint: number = pk.getFingerprint();
-        const bytes: Uint8Array = pk.serialize();
-        pk.delete();
-        aggPk.delete();
-        aggPk2.delete();
-    });
+        it('Signature', () => {
+            strictEqual(Signature.SIGNATURE_SIZE, 96);
+            const info = AggregationInfo.fromMsg(PublicKey.fromBytes(getPkBytes()), getMessageBytes());
+            const sig = Signature.fromBytesAndAggregationInfo(getSignatureBytes(), info);
+            const aggSig = Signature.aggregateSigs([sig]);
+            const sig2 = Signature.fromBytes(getSignatureBytes());
+            const isValid: boolean = sig.verify();
+            const serialized: Uint8Array = sig.serialize();
+            const aggInfo = sig.getAggregationInfo();
+            ok(isValid);
+            sig.setAggregationInfo(info);
+            sig.delete();
+            aggSig.delete();
+            sig2.delete();
+            aggInfo.delete();
+        });
 
-    it('AggregationInfo', () => {
-        const infoFromHash: AggregationInfo = AggregationInfo.fromMsgHash(PublicKey.fromBytes(getPkBytes()), getMessageHash());
-        const info: AggregationInfo = AggregationInfo.fromMsg(PublicKey.fromBytes(getPkBytes()), getMessageBytes());
-        const infoFromBuffers: AggregationInfo = AggregationInfo.fromBuffers([PublicKey.fromBytes(getPkBytes())], [getMessageHash()], [Uint8Array.from([1])]);
-        const pks: PublicKey[] = info.getPublicKeys();
-        const messageHashes: Uint8Array[] = info.getMessageHashes();
-        const exponents: Uint8Array[] = info.getExponents();
-        deepStrictEqual(pks[0].serialize(), getPkBytes());
-        deepStrictEqual(messageHashes[0], getMessageHash());
-        deepStrictEqual(exponents[0], Uint8Array.from([1]));
-        infoFromHash.delete();
-        info.delete();
-        infoFromBuffers.delete();
-        pks.forEach(pk => pk.delete());
-    });
+        it('PublicKey', () => {
+            strictEqual(PublicKey.PUBLIC_KEY_SIZE, 48);
+            const pk = PublicKey.fromBytes(getPkBytes());
+            const aggPk = PublicKey.aggregate([pk]);
+            const aggPk2 = PublicKey.aggregateInsecure([pk]);
+            const fingerprint: number = pk.getFingerprint();
+            const bytes: Uint8Array = pk.serialize();
+            pk.delete();
+            aggPk.delete();
+            aggPk2.delete();
+        });
 
-    it('ExtendedPrivateKey', () => {
-        strictEqual(ExtendedPrivateKey.EXTENDED_PRIVATE_KEY_SIZE, 77);
-        const esk: ExtendedPrivateKey = ExtendedPrivateKey.fromSeed(getSkSeed());
-        ExtendedPrivateKey.fromBytes(getEskBytes());
-        const privateChild: ExtendedPrivateKey = esk.privateChild(1);
-        const publicChild: ExtendedPublicKey = esk.publicChild(1);
-        const version: number = esk.getVersion();
-        const depth: number = esk.getDepth();
-        const parentFingerprint: number = esk.getParentFingerprint();
-        const childNumber: number = esk.getChildNumber();
-        const chainCode: ChainCode = esk.getChainCode();
-        const sk: PrivateKey = esk.getPrivateKey();
-        const pk: PublicKey = esk.getPublicKey();
-        const epk: ExtendedPublicKey = esk.getExtendedPublicKey();
-        const bytes: Uint8Array = esk.serialize();
-        esk.delete();
-        privateChild.delete();
-        publicChild.delete();
-        chainCode.delete();
-        sk.delete();
-        pk.delete();
-        epk.delete();
-    });
+        it('AggregationInfo', () => {
+            const infoFromHash = AggregationInfo.fromMsgHash(PublicKey.fromBytes(getPkBytes()), getMessageHash());
+            const info = AggregationInfo.fromMsg(PublicKey.fromBytes(getPkBytes()), getMessageBytes());
+            const infoFromBuffers = AggregationInfo.fromBuffers([PublicKey.fromBytes(getPkBytes())], [getMessageHash()], [Uint8Array.from([1])]);
+            const pks = info.getPublicKeys();
+            const messageHashes: Uint8Array[] = info.getMessageHashes();
+            const exponents: Uint8Array[] = info.getExponents();
+            deepStrictEqual(pks[0].serialize(), getPkBytes());
+            deepStrictEqual(messageHashes[0], getMessageHash());
+            deepStrictEqual(exponents[0], Uint8Array.from([1]));
+            infoFromHash.delete();
+            info.delete();
+            infoFromBuffers.delete();
+            pks.forEach(pk => pk.delete());
+        });
 
-    it('ExtendedPublicKey', () => {
-        strictEqual(ExtendedPublicKey.VERSION, 1);
-        strictEqual(ExtendedPublicKey.EXTENDED_PUBLIC_KEY_SIZE, 93);
-        const epk: ExtendedPublicKey = ExtendedPublicKey.fromBytes(getEpkBytes());
-        const publicChild: ExtendedPublicKey = epk.publicChild(1);
-        const version: number = epk.getVersion();
-        const depth: number = epk.getDepth();
-        const parentFingerprint: number = epk.getParentFingerprint();
-        const childNumber: number = epk.getChildNumber();
-        const pk: PublicKey = epk.getPublicKey();
-        const chainCode: ChainCode = epk.getChainCode();
-        const bytes: Uint8Array = epk.serialize();
-        epk.delete();
-        publicChild.delete();
-        pk.delete();
-        chainCode.delete();
-    });
+        it('ExtendedPrivateKey', () => {
+            strictEqual(ExtendedPrivateKey.EXTENDED_PRIVATE_KEY_SIZE, 77);
+            const esk = ExtendedPrivateKey.fromSeed(getSkSeed());
+            ExtendedPrivateKey.fromBytes(getEskBytes());
+            const privateChild = esk.privateChild(1);
+            const publicChild = esk.publicChild(1);
+            const version: number = esk.getVersion();
+            const depth: number = esk.getDepth();
+            const parentFingerprint: number = esk.getParentFingerprint();
+            const childNumber: number = esk.getChildNumber();
+            const chainCode = esk.getChainCode();
+            const sk = esk.getPrivateKey();
+            const pk = esk.getPublicKey();
+            const epk = esk.getExtendedPublicKey();
+            const bytes: Uint8Array = esk.serialize();
+            esk.delete();
+            privateChild.delete();
+            publicChild.delete();
+            chainCode.delete();
+            sk.delete();
+            pk.delete();
+            epk.delete();
+        });
 
-    it('ChainCode', () => {
-        strictEqual(ChainCode.CHAIN_CODE_SIZE, 32);
-        const chainCode: ChainCode = ChainCode.fromBytes(getChainCodeBytes());
-        const bytes: Uint8Array = chainCode.serialize();
-        chainCode.delete();
-    });
+        it('ExtendedPublicKey', () => {
+            strictEqual(ExtendedPublicKey.VERSION, 1);
+            strictEqual(ExtendedPublicKey.EXTENDED_PUBLIC_KEY_SIZE, 93);
+            const epk = ExtendedPublicKey.fromBytes(getEpkBytes());
+            const publicChild = epk.publicChild(1);
+            const version: number = epk.getVersion();
+            const depth: number = epk.getDepth();
+            const parentFingerprint: number = epk.getParentFingerprint();
+            const childNumber: number = epk.getChildNumber();
+            const pk = epk.getPublicKey();
+            const chainCode = epk.getChainCode();
+            const bytes: Uint8Array = epk.serialize();
+            epk.delete();
+            publicChild.delete();
+            pk.delete();
+            chainCode.delete();
+        });
 
-    it('Threshold', () => {
-        const commitments = [
-            PublicKey.fromBytes(Uint8Array.from(Buffer.from('93075db5c398bd2682dfab816a920023e8c0337a42fafc93c0bfab937400b6e7dafa5e456f2fa127979ff9c9a140127b', 'hex'))),
-            PublicKey.fromBytes(Uint8Array.from(Buffer.from('1304180c71f137a1dc4c39c6e997285f55d9dd11f53c52f8fc7702a5b08f529190ffc01b8b6b28b64ee9704f26ca02c3', 'hex'))),
-        ];
-        const fragments = [
-            PrivateKey.fromBytes(Uint8Array.from(Buffer.from('0b5205ed2c9aa86391dc8c7de15efa868073d83fb782f92de81e3d21916e296e', 'hex')), false),
-            PrivateKey.fromBytes(Uint8Array.from(Buffer.from('56720e3ca7a2d6856fa16ef94eb2c2957066b849cea8a4da7fde0613efbc5401', 'hex')), false),
-            PrivateKey.fromBytes(Uint8Array.from(Buffer.from('49d151bb34da1f1957077e231e7cdf564f418b74cb9b3b1c751714cb649631c3', 'hex')), false),
-        ];
-        const sk: PrivateKey = Threshold.create(commitments, fragments, 2, 3);
-        const sig: InsecureSignature = Threshold.signWithCoefficient(sk, Uint8Array.from([1, 2, 3]), 2, [1, 3]);
-        const aggSig: InsecureSignature = Threshold.aggregateUnitSigs([], Uint8Array.from([1, 2, 3]), [1, 2]);
-        const isValid: boolean = Threshold.verifySecretFragment(1, sk, [], 3);
-        sk.delete();
-        sig.delete();
-        aggSig.delete();
-    });
+        it('ChainCode', () => {
+            strictEqual(ChainCode.CHAIN_CODE_SIZE, 32);
+            const chainCode = ChainCode.fromBytes(getChainCodeBytes());
+            const bytes: Uint8Array = chainCode.serialize();
+            chainCode.delete();
+        });
 
-    it('GROUP_ORDER', () => {
-        strictEqual(GROUP_ORDER, '73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001');
-    });
+        it('Threshold', () => {
+            const commitments = [
+                PublicKey.fromBytes(Uint8Array.from(Buffer.from('93075db5c398bd2682dfab816a920023e8c0337a42fafc93c0bfab937400b6e7dafa5e456f2fa127979ff9c9a140127b', 'hex'))),
+                PublicKey.fromBytes(Uint8Array.from(Buffer.from('1304180c71f137a1dc4c39c6e997285f55d9dd11f53c52f8fc7702a5b08f529190ffc01b8b6b28b64ee9704f26ca02c3', 'hex'))),
+            ];
+            const fragments = [
+                PrivateKey.fromBytes(Uint8Array.from(Buffer.from('0b5205ed2c9aa86391dc8c7de15efa868073d83fb782f92de81e3d21916e296e', 'hex')), false),
+                PrivateKey.fromBytes(Uint8Array.from(Buffer.from('56720e3ca7a2d6856fa16ef94eb2c2957066b849cea8a4da7fde0613efbc5401', 'hex')), false),
+                PrivateKey.fromBytes(Uint8Array.from(Buffer.from('49d151bb34da1f1957077e231e7cdf564f418b74cb9b3b1c751714cb649631c3', 'hex')), false),
+            ];
+            const sk = Threshold.create(commitments, fragments, 2, 3);
+            const sig = Threshold.signWithCoefficient(sk, Uint8Array.from([1, 2, 3]), 2, [1, 3]);
+            const aggSig = Threshold.aggregateUnitSigs([], Uint8Array.from([1, 2, 3]), [1, 2]);
+            const isValid: boolean = Threshold.verifySecretFragment(1, sk, [], 3);
+            sk.delete();
+            sig.delete();
+            aggSig.delete();
+        });
 
-    it('DHKeyExchange', () => {
-        const sk = PrivateKey.fromSeed(getSkSeed());
-        const pk = PublicKey.fromBytes(getPkBytes());
-        const result: PublicKey = DHKeyExchange(sk, pk);
-        strictEqual(result.serialize().length, PublicKey.PUBLIC_KEY_SIZE);
-        sk.delete();
-        pk.delete();
-        result.delete();
+        it('GROUP_ORDER', () => {
+            strictEqual(GROUP_ORDER, '73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001');
+        });
+
+        it('DHKeyExchange', () => {
+            const sk = PrivateKey.fromSeed(getSkSeed());
+            const pk = PublicKey.fromBytes(getPkBytes());
+            const result = DHKeyExchange(sk, pk);
+            strictEqual(result.serialize().length, PublicKey.PUBLIC_KEY_SIZE);
+            sk.delete();
+            pk.delete();
+            result.delete();
+        });
     });
 });

--- a/js_build.sh
+++ b/js_build.sh
@@ -5,5 +5,5 @@ git submodule update --init --recursive
 mkdir js_build
 cd js_build
 
-cmake ../ -DCMAKE_TOOLCHAIN_FILE=/home/anton/Programs/emsdk/emscripten/1.38.25/cmake/Modules/Platform/Emscripten.cmake
+cmake ../ -DCMAKE_TOOLCHAIN_FILE=$(realpath $(which emcc))/cmake/Modules/Platform/Emscripten.cmake
 cmake --build . --


### PR DESCRIPTION
Commit messages should explain what happened on each step, but here is a gist:
* Wasm is a separate file now and is not bundled inside of JavaScript
* WebAssembly instantiation is now asynchronous and works in modern browsers (see #76)
* Above causes major API change
* Compilation was tweaked to produce smaller output
* JS build script was tweaked to work on any machine with Emscripten installed regardless of specific location
* Minor tweaks to package.json and version bump

Fixes #76