### PR TITLE
Add extra check for signature deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,13 +264,10 @@ keybase team request-access chia_network.public
 * Objects allocate and free their own memory
 * Use cpplint with default rules
 
-### TODO
-* Serialize aggregation info
-* Secure allocation during signing, key derivation
-* Remove unnecessary dependency files
-* Constant time and side channel attacks
-* Adaptor signatures / Blind signatures
-* More tests vectors (failed verifications, etc)
+
+There are three types of signatures: InsecureSignatures (simple signatures which are not secure by themselves, due to rogue public keys),
+Signatures (secure signatures that require AggregationInfo to aggregate),
+and PrependSignatures, which prepend public keys to messages, making them secure.
 
 
 ### Specification and test vectors

--- a/python-bindings/README.md
+++ b/python-bindings/README.md
@@ -24,6 +24,9 @@ from blspy import (PrivateKey, PublicKey, InsecureSignature, Signature,
                    Threshold, Util)
 ```
 
+There are three types of signatures: InsecureSignatures (simple signatures which are not secure by themselves, due to rogue public keys),
+Signatures (secure signatures that require AggregationInfo to aggregate),
+and PrependSignatures, which prepend public keys to messages, making them secure.
 
 #### Creating keys and signatures
 ```python

--- a/python-bindings/test.py
+++ b/python-bindings/test.py
@@ -352,6 +352,25 @@ def no_throw_bad_sig():
         return
     assert(False)
 
+def throw_wrong_type():
+    private_key = ExtendedPrivateKey.from_seed(b"foo").get_private_key()
+
+    message_hash = bytes([10] * 32)
+
+    sig_prepend = private_key.sign_prepend_prehashed(message_hash).serialize()
+    sig_secure = private_key.sign_prehashed(message_hash).serialize()
+
+    try:
+        Signature.from_bytes(sig_prepend)
+    except ValueError:
+        try:
+            PrependSignature.from_bytes(sig_secure)
+        except ValueError:
+            return
+        assert False
+    assert False
+
+
 def additional_python_methods():
     private_key = PrivateKey.from_seed(b'123')
     s1 = private_key.sign(b'message')
@@ -375,7 +394,9 @@ test_vectors2()
 test_vectors3()
 test_vectors4()
 no_throw_bad_sig()
+throw_wrong_type()
 additional_python_methods()
+
 
 print("\nAll tests passed.")
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='blspy',
-    version='0.1.10',
+    version='0.1.11',
     author='Mariano Sorgente',
     author_email='mariano@chia.net',
     description='BLS signatures in c++ (python bindings)',

--- a/src/signature.cpp
+++ b/src/signature.cpp
@@ -175,6 +175,9 @@ void InsecureSignature::CompressPoint(uint8_t* result, const g2_t* point) {
 /// Signature
 
 Signature Signature::FromBytes(const uint8_t* data) {
+    if ((data[0] & 0x40) > 0) {
+        throw std::invalid_argument("Invalid signature. Second bit is set, so it's a PrependSignature.");
+    }
     Signature result;
     result.sig = InsecureSignature::FromBytes(data);
     return result;


### PR DESCRIPTION
Deserializing a PrependSignature as a Signature should throw an error.