### PR TITLE
Build python 3.8 binary wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         python -m cibuildwheel --output-dir dist
       env:
         # Python 3.7 and 3.8
-        CIBW_BUILD: cp37-* cp37-*
+        CIBW_BUILD: 'cp37-*' 'cp37-*'
         # don't build i686 targets, can't seem to find cmake for these
         CIBW_SKIP: '*-manylinux_i686'
         # we need boost

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         python -m cibuildwheel --output-dir dist
       env:
         # Python 3.7 and 3.8
-        CIBW_BUILD: 'cp37-*' 'cp37-*'
+        CIBW_BUILD: cp37-* cp38-*
         # don't build i686 targets, can't seem to find cmake for these
         CIBW_SKIP: '*-manylinux_i686'
         # we need boost

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,8 @@ jobs:
       run: |
         python -m cibuildwheel --output-dir dist
       env:
-        # build just python 3.7
-        CIBW_BUILD: cp37-*
+        # Python 3.7 and 3.8
+        CIBW_BUILD: cp37-* cp37-*
         # don't build i686 targets, can't seem to find cmake for these
         CIBW_SKIP: '*-manylinux_i686'
         # we need boost


### PR DESCRIPTION
This builds binary wheels for macos and linux for both python 3.7 and 3.8.