### PR TITLE
Include stdlib.h instead of alloca.h on FreeBSD

### DIFF
--- a/contrib/relic/include/relic_alloc.h
+++ b/contrib/relic/include/relic_alloc.h
@@ -52,7 +52,7 @@
 
 #else /* _MSC_VER */
 
-#if defined(__OpenBSD__)
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
 #include <stdlib.h>
 #else
 #include <alloca.h>


### PR DESCRIPTION
Tested on FreeBSD amd64 11.3 and 12.1.