### PR TITLE
Add fast pub aggregation

### DIFF
--- a/src/schemes.hpp
+++ b/src/schemes.hpp
@@ -72,6 +72,8 @@ public:
 
     static G2Element Aggregate(const vector<G2Element> &signatures);
 
+    static G1Element Aggregate(const vector<G1Element> &publicKeys);
+
     static bool AggregateVerify(
         const vector<vector<uint8_t>> &pubkeys,
         const vector<vector<uint8_t>> &messages,
@@ -121,6 +123,11 @@ public:
     static G2Element Aggregate(const vector<G2Element> &signatures)
     {
         return CoreMPL::Aggregate(signatures);
+    }
+
+    static G1Element Aggregate(const vector<G1Element> &publicKeys)
+    {
+        return CoreMPL::Aggregate(publicKeys);
     }
 
     static G2Element Sign(
@@ -187,6 +194,11 @@ public:
     static G2Element Aggregate(const vector<G2Element> &signatures)
     {
         return CoreMPL::Aggregate(signatures);
+    }
+
+    static G1Element Aggregate(const vector<G1Element> &publicKeys)
+    {
+        return CoreMPL::Aggregate(publicKeys);
     }
 
     static G2Element Sign(
@@ -261,6 +273,11 @@ public:
     static G2Element Aggregate(const vector<G2Element> &signatures)
     {
         return CoreMPL::Aggregate(signatures);
+    }
+
+    static G1Element Aggregate(const vector<G1Element> &publicKeys)
+    {
+        return CoreMPL::Aggregate(publicKeys);
     }
 
     static G2Element Sign(


### PR DESCRIPTION
At the moment public key aggregation is only possible through the "+" operator override. This is extremely slow for large quantities of public keys.

This pull requests adds a dedicated aggregation function for public keys.
The speedup factor running a smaller benchmark already resulted in around 25x

---- Old------
PopScheme verification
Total: 500 runs in 74 ms
Avg: 0.148 ms

---- New------
PopScheme verification
Total: 500 runs in 3 ms
Avg: 0.006 ms
