### PR TITLE
regress relic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
   relic
   GIT_REPOSITORY https://github.com/relic-toolkit/relic.git
-  GIT_TAG        origin/master
+  GIT_TAG        ed485dccb23f9f5615eac5c71b3e37bd1bc8fb3e
 )
 FetchContent_MakeAvailable(relic)
 


### PR DESCRIPTION
Fixed for broken relic?

Looks like something bad happened here
https://github.com/relic-toolkit/relic/commit/bb41dc8871244c9abd23268ca065d459a68b79eb
