### PR TITLE
fix resource management in PrivateKey class

### DIFF
--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -67,21 +67,6 @@ PrivateKey::PrivateKey(PrivateKey &&k)
 
 PrivateKey::~PrivateKey() { if(keydata !=NULL) Util::SecFree(keydata); }
 
-PrivateKey& PrivateKey::operator=(PrivateKey const& k) &
-{
-    if (!keydata) AllocateKeyData();
-    bn_copy(*keydata, *k.keydata);
-    return *this;
-}
-
-PrivateKey& PrivateKey::operator=(PrivateKey&& k) &
-{
-    if (keydata) Util::SecFree(keydata);
-    keydata = std::exchange(k.keydata, nullptr);
-    return *this;
-}
->>>>>>> fix resource management in PrivateKey class. add assignment operators to properly copy value (instead of pointer) or move (instead of copying pointer, resulting in double-free)
-
 G1Element PrivateKey::GetG1Element() const
 {
     g1_t *p = Util::SecAlloc<g1_t>(1);

--- a/src/privatekey.hpp
+++ b/src/privatekey.hpp
@@ -45,6 +45,9 @@ class PrivateKey {
     PrivateKey(const PrivateKey &k);
     PrivateKey(PrivateKey &&k);
 
+    PrivateKey& operator=(PrivateKey const&) &;
+    PrivateKey& operator=(PrivateKey&&) &;
+
     ~PrivateKey();
 
     G1Element GetG1Element() const;
@@ -83,7 +86,7 @@ class PrivateKey {
 
  private:
     // Don't allow public construction, force static methods
-    PrivateKey() {}
+    PrivateKey() = default;
 
     // Allocate memory for private key
     void AllocateKeyData();

--- a/src/privatekey.hpp
+++ b/src/privatekey.hpp
@@ -45,8 +45,8 @@ class PrivateKey {
     PrivateKey(const PrivateKey &k);
     PrivateKey(PrivateKey &&k);
 
-    PrivateKey& operator=(PrivateKey const&) &;
-    PrivateKey& operator=(PrivateKey&&) &;
+    PrivateKey& operator=(PrivateKey const&) = delete;
+    PrivateKey& operator=(PrivateKey&&) = delete;
 
     ~PrivateKey();
 


### PR DESCRIPTION
add assignment operators to properly copy value (instead of pointer) or move (instead of copying pointer, resulting in double-free)