### PR TITLE
src: Avoid using `g1_t` and `g2_t` pointer if not required

### DIFF
--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -67,10 +67,10 @@ G1Element G1Element::FromByteVector(const std::vector<uint8_t>& bytevec)
     return G1Element::FromBytes({bytevec});
 }
 
-G1Element G1Element::FromNative(const g1_t* element)
+G1Element G1Element::FromNative(const g1_t element)
 {
     G1Element ele = G1Element();
-    g1_copy(ele.p, *element);
+    g1_copy(ele.p, element);
     ele.CheckValid();
     return ele;
 }
@@ -90,7 +90,7 @@ G1Element G1Element::FromMessage(const Bytes& message,
     g1_null(ans);
     g1_new(ans);
     ep_map_dst(ans, message.begin(), (int)message.size(), dst, dst_len);
-    G1Element ret = G1Element::FromNative(&ans);
+    G1Element ret = G1Element::FromNative(ans);
     g1_free(ans);
     return ret;
 }
@@ -136,8 +136,8 @@ void G1Element::CheckValid() const {
     BLS::CheckRelicErrors();
 }
 
-void G1Element::ToNative(g1_t* output) const {
-    g1_copy(*output, this->p);
+void G1Element::ToNative(g1_t output) const {
+    g1_copy(output, this->p);
 }
 
 G1Element G1Element::Negate() const
@@ -199,7 +199,7 @@ G1Element operator+(const G1Element& a, const G1Element& b)
     g1_t ans;
     g1_new(ans);
     g1_add(ans, a.p, b.p);
-    G1Element ret = G1Element::FromNative(&ans);
+    G1Element ret = G1Element::FromNative(ans);
     g1_free(ans);
     return ret;
 }
@@ -215,7 +215,7 @@ G1Element operator*(const G1Element& a, const bn_t& k)
     g1_mul(ans, nonConstA.p, nonConstK[0]);
     bn_free(nonConstK[0]);
     Util::SecFree(nonConstK);
-    G1Element ret =  G1Element::FromNative(&ans);
+    G1Element ret =  G1Element::FromNative(ans);
     g1_free(ans);
     return ret;
 }
@@ -280,10 +280,10 @@ G2Element G2Element::FromByteVector(const std::vector<uint8_t>& bytevec)
     return G2Element::FromBytes({bytevec});
 }
 
-G2Element G2Element::FromNative(const g2_t* element)
+G2Element G2Element::FromNative(const g2_t element)
 {
     G2Element ele = G2Element();
-    g2_copy(ele.q, *(g2_t*)element);
+    g2_copy(ele.q, (g2_st*)element);
     ele.CheckValid();
     return ele;
 }
@@ -303,7 +303,7 @@ G2Element G2Element::FromMessage(const Bytes& message,
     g2_null(ans);
     g2_new(ans);
     ep2_map_dst(ans, message.begin(), (int)message.size(), dst, dst_len);
-    G2Element ret = G2Element::FromNative(&ans);
+    G2Element ret = G2Element::FromNative(ans);
     g2_free(ans);
     return ret;
 }
@@ -345,8 +345,8 @@ void G2Element::CheckValid() const {
     BLS::CheckRelicErrors();
 }
 
-void G2Element::ToNative(g2_t* output) const {
-    g2_copy(*output, *(g2_t*)&this->q);
+void G2Element::ToNative(g2_t output) const {
+    g2_copy(output, *(g2_t*)&this->q);
 }
 
 G2Element G2Element::Negate() const
@@ -408,7 +408,7 @@ G2Element operator+(const G2Element& a, const G2Element& b)
     G2Element nonConstB(b);
     g2_t ans;
     g2_add(ans, nonConstA.q, nonConstB.q);
-    return G2Element::FromNative(&ans);
+    return G2Element::FromNative(ans);
 }
 
 G2Element operator*(const G2Element& a, const bn_t& k)
@@ -421,7 +421,7 @@ G2Element operator*(const G2Element& a, const bn_t& k)
     g2_mul(ans, nonConstA.q, nonConstK[0]);
     bn_free(nonConstK[0]);
     Util::SecFree(nonConstK);
-    G2Element ret = G2Element::FromNative(&ans);
+    G2Element ret = G2Element::FromNative(ans);
     g2_free(ans);
     return ret;
 }

--- a/src/elements.hpp
+++ b/src/elements.hpp
@@ -41,7 +41,7 @@ public:
 
     static G1Element FromBytes(const Bytes& bytes);
     static G1Element FromByteVector(const std::vector<uint8_t> &bytevec);
-    static G1Element FromNative(const g1_t *element);
+    static G1Element FromNative(const g1_t element);
     static G1Element FromMessage(const std::vector<uint8_t> &message,
                                  const uint8_t *dst,
                                  int dst_len);
@@ -52,7 +52,7 @@ public:
     static G1Element Infinity();  // infinity / unity
 
     void CheckValid() const;
-    void ToNative(g1_t* output) const;
+    void ToNative(g1_t output) const;
     G1Element Negate() const;
     uint32_t GetFingerprint() const;
     std::vector<uint8_t> Serialize() const;
@@ -79,7 +79,7 @@ public:
 
     static G2Element FromBytes(const Bytes& bytes);
     static G2Element FromByteVector(const std::vector<uint8_t> &bytevec);
-    static G2Element FromNative(const g2_t *element);
+    static G2Element FromNative(const g2_t element);
     static G2Element FromMessage(const std::vector<uint8_t>& message,
                                  const uint8_t* dst,
                                  int dst_len);
@@ -90,7 +90,7 @@ public:
     static G2Element Infinity();  // infinity/unity
 
     void CheckValid() const;
-    void ToNative(g2_t* output) const;
+    void ToNative(g2_t output) const;
     G2Element Negate() const;
     std::vector<uint8_t> Serialize() const;
 

--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -103,11 +103,11 @@ const G1Element& PrivateKey::GetG1Element() const
 {
     if (!fG1CacheValid) {
         CheckKeyData();
-        g1_t *p = Util::SecAlloc<g1_t>(1);
-        g1_mul_gen(*p, keydata);
+        g1_st *p = Util::SecAlloc<g1_st>(1);
+        g1_mul_gen(p, keydata);
 
         g1Cache = G1Element::FromNative(p);
-        Util::SecFree(*p);
+        Util::SecFree(p);
         fG1CacheValid = true;
     }
     return g1Cache;
@@ -117,11 +117,11 @@ const G2Element& PrivateKey::GetG2Element() const
 {
     if (!fG2CacheValid) {
         CheckKeyData();
-        g2_t *q = Util::SecAlloc<g2_t>(1);
-        g2_mul_gen(*q, keydata);
+        g2_st *q = Util::SecAlloc<g2_st>(1);
+        g2_mul_gen(q, keydata);
 
         g2Cache = G2Element::FromNative(q);
-        Util::SecFree(*q);
+        Util::SecFree(q);
         fG2CacheValid = true;
     }
     return g2Cache;
@@ -130,9 +130,9 @@ const G2Element& PrivateKey::GetG2Element() const
 G1Element operator*(const G1Element &a, const PrivateKey &k)
 {
     k.CheckKeyData();
-    g1_t* ans = Util::SecAlloc<g1_t>(1);
+    g1_st* ans = Util::SecAlloc<g1_st>(1);
     a.ToNative(ans);
-    g1_mul(*ans, *ans, k.keydata);
+    g1_mul(ans, ans, k.keydata);
     G1Element ret = G1Element::FromNative(ans);
     Util::SecFree(ans);
     return ret;
@@ -143,9 +143,9 @@ G1Element operator*(const PrivateKey &k, const G1Element &a) { return a * k; }
 G2Element operator*(const G2Element &a, const PrivateKey &k)
 {
     k.CheckKeyData();
-    g2_t* ans = Util::SecAlloc<g2_t>(1);
+    g2_st* ans = Util::SecAlloc<g2_st>(1);
     a.ToNative(ans);
-    g2_mul(*ans, *ans, k.keydata);
+    g2_mul(ans, ans, k.keydata);
     G2Element ret = G2Element::FromNative(ans);
     Util::SecFree(ans);
     return ret;
@@ -156,12 +156,12 @@ G2Element operator*(const PrivateKey &k, const G2Element &a) { return a * k; }
 G2Element PrivateKey::GetG2Power(const G2Element& element) const
 {
     CheckKeyData();
-    g2_t *q = Util::SecAlloc<g2_t>(1);
+    g2_st* q = Util::SecAlloc<g2_st>(1);
     element.ToNative(q);
-    g2_mul(*q, *q, keydata);
+    g2_mul(q, q, keydata);
 
     const G2Element ret = G2Element::FromNative(q);
-    Util::SecFree(*q);
+    Util::SecFree(q);
     return ret;
 }
 
@@ -223,10 +223,10 @@ G2Element PrivateKey::SignG2(
 {
     CheckKeyData();
 
-    g2_t* pt = Util::SecAlloc<g2_t>(1);
+    g2_st* pt = Util::SecAlloc<g2_st>(1);
 
-    ep2_map_dst(*pt, msg, len, dst, dst_len);
-    g2_mul(*pt, *pt, keydata);
+    ep2_map_dst(pt, msg, len, dst, dst_len);
+    g2_mul(pt, pt, keydata);
     G2Element ret = G2Element::FromNative(pt);
     Util::SecFree(pt);
     return ret;


### PR DESCRIPTION
Based on #168