### PR TITLE
src|python: Force explicit construction of class `Bytes`

### DIFF
--- a/python-bindings/pythonbindings.cpp
+++ b/python-bindings/pythonbindings.cpp
@@ -45,7 +45,7 @@ PYBIND11_MODULE(blspy, m)
                         "Length of bytes object not equal to PrivateKey::SIZE");
                 }
                 auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
-                return PrivateKey::FromBytes({data_ptr, PrivateKey::PRIVATE_KEY_SIZE});
+                return PrivateKey::FromBytes(Bytes(data_ptr, PrivateKey::PRIVATE_KEY_SIZE));
             })
         .def(
             "__bytes__",
@@ -314,7 +314,7 @@ PYBIND11_MODULE(blspy, m)
                         "Length of bytes object not equal to G1Element::SIZE");
                 }
                 auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
-                return G1Element::FromBytes({data_ptr, G1Element::SIZE});
+                return G1Element::FromBytes(Bytes(data_ptr, G1Element::SIZE));
             })
         .def("generator", &G1Element::Generator)
         .def("from_message", py::overload_cast<const std::vector<uint8_t>&, const uint8_t*, int>(&G1Element::FromMessage))
@@ -414,7 +414,7 @@ PYBIND11_MODULE(blspy, m)
                         "Length of bytes object not equal to G2Element::SIZE");
                 }
                 auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
-                return G2Element::FromBytes({data_ptr, G2Element::SIZE});
+                return G2Element::FromBytes(Bytes(data_ptr, G2Element::SIZE));
             })
         .def("generator", &G2Element::Generator)
         .def("from_message", py::overload_cast<const std::vector<uint8_t>&, const uint8_t*, int>(&G2Element::FromMessage))

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -79,7 +79,7 @@ G1Element G1Element::FromMessage(const std::vector<uint8_t>& message,
                                  const uint8_t* dst,
                                  int dst_len)
 {
-    return FromMessage(Bytes{message}, dst, dst_len);
+    return FromMessage(Bytes(message), dst, dst_len);
 }
 
 G1Element G1Element::FromMessage(const Bytes& message,
@@ -276,7 +276,7 @@ G2Element G2Element::FromMessage(const std::vector<uint8_t>& message,
                                  const uint8_t* dst,
                                  int dst_len)
 {
-    return FromMessage(Bytes{message}, dst, dst_len);
+    return FromMessage(Bytes(message), dst, dst_len);
 }
 
 G2Element G2Element::FromMessage(const Bytes& message,

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -64,7 +64,7 @@ G1Element G1Element::FromBytes(const Bytes& bytes)
 
 G1Element G1Element::FromByteVector(const std::vector<uint8_t>& bytevec)
 {
-    return G1Element::FromBytes({bytevec});
+    return G1Element::FromBytes(Bytes(bytevec));
 }
 
 G1Element G1Element::FromNative(const g1_t element)
@@ -261,7 +261,7 @@ G2Element G2Element::FromBytes(const Bytes& bytes)
 
 G2Element G2Element::FromByteVector(const std::vector<uint8_t>& bytevec)
 {
-    return G2Element::FromBytes({bytevec});
+    return G2Element::FromBytes(Bytes(bytevec));
 }
 
 G2Element G2Element::FromNative(const g2_t element)

--- a/src/hdkeys.hpp
+++ b/src/hdkeys.hpp
@@ -37,7 +37,7 @@ class HDKeys {
 
     static PrivateKey KeyGen(const std::vector<uint8_t>& seed)
     {
-        return KeyGen(Bytes{seed});
+        return KeyGen(Bytes(seed));
     }
     
     static PrivateKey KeyGen(const Bytes& seed)

--- a/src/hdkeys.hpp
+++ b/src/hdkeys.hpp
@@ -97,7 +97,7 @@ class HDKeys {
 
         uint8_t *skBytes = Util::SecAlloc<uint8_t>(32);
         bn_write_bin(skBytes, 32, *skBn);
-        PrivateKey k = PrivateKey::FromBytes({skBytes, 32});
+        PrivateKey k = PrivateKey::FromBytes(Bytes(skBytes, 32));
 
         Util::SecFree(prk);
         Util::SecFree(ikmHkdf);
@@ -166,7 +166,7 @@ class HDKeys {
         Util::IntToFourBytes(buf + G1Element::SIZE, index);
         Util::Hash256(digest, buf, G1Element::SIZE + 4);
 
-        PrivateKey ret = PrivateKey::Aggregate({parentSk, PrivateKey::FromBytes({digest, HASH_LEN}, true)});
+        PrivateKey ret = PrivateKey::Aggregate({parentSk, PrivateKey::FromBytes(Bytes(digest, HASH_LEN), true)});
 
         Util::SecFree(buf);
         Util::SecFree(digest);

--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -42,7 +42,7 @@ PrivateKey PrivateKey::FromBytes(const Bytes& bytes, bool modOrder)
 // Construct a private key from a bytearray.
 PrivateKey PrivateKey::FromByteVector(const std::vector<uint8_t> bytes, bool modOrder)
 {
-    return PrivateKey::FromBytes({bytes}, modOrder);
+    return PrivateKey::FromBytes(Bytes(bytes), modOrder);
 }
 
 PrivateKey::PrivateKey() {

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -82,9 +82,9 @@ bool CoreMPL::Verify(const vector<uint8_t> &pubkey,
                      const vector<uint8_t> &message,  // unhashed
                      const vector<uint8_t> &signature)
 {
-    return CoreMPL::Verify(G1Element::FromBytes({pubkey}),
+    return CoreMPL::Verify(G1Element::FromBytes(Bytes(pubkey)),
                            Bytes{message},
-                           G2Element::FromBytes({signature}));
+                           G2Element::FromBytes(Bytes(signature)));
 }
 
 bool CoreMPL::Verify(const Bytes& pubkey, const Bytes& message, const Bytes& signature)
@@ -361,7 +361,7 @@ bool AugSchemeMPL::Verify(const Bytes& pubkey,
     vector<uint8_t> augMessage(pubkey.begin(), pubkey.end());
     augMessage.reserve(augMessage.size() + message.size());
     augMessage.insert(augMessage.end(), message.begin(), message.end());
-    return CoreMPL::Verify(pubkey, augMessage, signature);
+    return CoreMPL::Verify(pubkey, Bytes(augMessage), Bytes(signature));
 }
 
 bool AugSchemeMPL::Verify(const G1Element &pubkey,
@@ -508,7 +508,7 @@ bool PopSchemeMPL::FastAggregateVerify(const vector<vector<uint8_t>> &pubkeys,
                                        const vector<uint8_t> &signature)
 {
     const std::vector<Bytes> vecPubKeyBytes(pubkeys.begin(), pubkeys.end());
-    return PopSchemeMPL::FastAggregateVerify(vecPubKeyBytes, message, signature);
+    return PopSchemeMPL::FastAggregateVerify(vecPubKeyBytes, Bytes(message), Bytes(signature));
 }
 
 bool PopSchemeMPL::FastAggregateVerify(const vector<Bytes>& pubkeys,

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -70,7 +70,7 @@ G1Element CoreMPL::SkToG1(const PrivateKey &seckey)
 
 G2Element CoreMPL::Sign(const PrivateKey &seckey, const vector<uint8_t> &message)
 {
-    return CoreMPL::Sign(seckey, Bytes{message});
+    return CoreMPL::Sign(seckey, Bytes(message));
 }
 
 G2Element CoreMPL::Sign(const PrivateKey& seckey, const Bytes& message)
@@ -83,7 +83,7 @@ bool CoreMPL::Verify(const vector<uint8_t> &pubkey,
                      const vector<uint8_t> &signature)
 {
     return CoreMPL::Verify(G1Element::FromBytes(Bytes(pubkey)),
-                           Bytes{message},
+                           Bytes(message),
                            G2Element::FromBytes(Bytes(signature)));
 }
 
@@ -156,7 +156,7 @@ bool CoreMPL::AggregateVerify(const vector<vector<uint8_t>> &pubkeys,
 {
     const std::vector<Bytes> vecPubKeyBytes(pubkeys.begin(), pubkeys.end());
     const std::vector<Bytes> vecMessagesBytes(messages.begin(), messages.end());
-    return CoreMPL::AggregateVerify(vecPubKeyBytes, vecMessagesBytes, Bytes{signature});
+    return CoreMPL::AggregateVerify(vecPubKeyBytes, vecMessagesBytes, Bytes(signature));
 }
 
 bool CoreMPL::AggregateVerify(const vector<Bytes>& pubkeys,
@@ -330,7 +330,7 @@ G2Element AugSchemeMPL::Sign(const PrivateKey &seckey,
                              const vector<uint8_t> &message,
                              const G1Element &prepend_pk)
 {
-    return AugSchemeMPL::Sign(seckey, Bytes{message}, prepend_pk);
+    return AugSchemeMPL::Sign(seckey, Bytes(message), prepend_pk);
 }
 
 // Used for prepending different augMessage
@@ -368,7 +368,7 @@ bool AugSchemeMPL::Verify(const G1Element &pubkey,
                           const vector<uint8_t> &message,
                           const G2Element &signature)
 {
-    return AugSchemeMPL::Verify(pubkey, Bytes{message}, signature);
+    return AugSchemeMPL::Verify(pubkey, Bytes(message), signature);
 }
 
 bool AugSchemeMPL::Verify(const G1Element& pubkey,
@@ -467,7 +467,7 @@ bool PopSchemeMPL::PopVerify(const G1Element &pubkey, const G2Element &signature
 
 bool PopSchemeMPL::PopVerify(const vector<uint8_t> &pubkey, const vector<uint8_t> &proof)
 {
-    return PopSchemeMPL::PopVerify(Bytes{pubkey}, Bytes{proof});
+    return PopSchemeMPL::PopVerify(Bytes(pubkey), Bytes(proof));
 }
 
 bool PopSchemeMPL::PopVerify(const Bytes& pubkey, const Bytes& proof)
@@ -489,7 +489,7 @@ bool PopSchemeMPL::FastAggregateVerify(const vector<G1Element> &pubkeys,
                                        const vector<uint8_t> &message,
                                        const G2Element &signature)
 {
-    return PopSchemeMPL::FastAggregateVerify(pubkeys, Bytes{message}, signature);
+    return PopSchemeMPL::FastAggregateVerify(pubkeys, Bytes(message), signature);
 }
 
 bool PopSchemeMPL::FastAggregateVerify(const vector<G1Element>& pubkeys,

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -944,26 +944,26 @@ TEST_CASE("Advanced") {
     SECTION("Bytes overloads")
     {
         std::vector<uint8_t> vecHash = getRandomSeed();
-        PrivateKey pk1 = BasicSchemeMPL().KeyGen(Bytes{getRandomSeed()});
-        PrivateKey pk2 = AugSchemeMPL().KeyGen(Bytes{getRandomSeed()});
-        PrivateKey pk3 = PopSchemeMPL().KeyGen(Bytes{getRandomSeed()});
+        PrivateKey pk1 = BasicSchemeMPL().KeyGen(Bytes(getRandomSeed()));
+        PrivateKey pk2 = AugSchemeMPL().KeyGen(Bytes(getRandomSeed()));
+        PrivateKey pk3 = PopSchemeMPL().KeyGen(Bytes(getRandomSeed()));
 
         std::vector<uint8_t> vecG1Element = pk1.GetG1Element().Serialize();
         G1Element g1Vector = G1Element::FromByteVector(vecG1Element);
-        G1Element g1Bytes = G1Element::FromBytes(Bytes{vecG1Element});
+        G1Element g1Bytes = G1Element::FromBytes(Bytes(vecG1Element));
         REQUIRE(g1Vector == g1Bytes);
 
         std::vector<uint8_t> vecG2Element = pk1.GetG2Element().Serialize();
         G2Element g2Vector = G2Element::FromByteVector(vecG2Element);
-        G2Element g2Bytes = G2Element::FromBytes(Bytes{vecG2Element});
+        G2Element g2Bytes = G2Element::FromBytes(Bytes(vecG2Element));
         REQUIRE(g2Vector == g2Bytes);
 
         G1Element g1MessageVector = G1Element::FromMessage(vecHash, vecHash.data(), vecHash.size());
-        G1Element g1MessageBytes = G1Element::FromMessage(Bytes{vecHash}, vecHash.data(), vecHash.size());
+        G1Element g1MessageBytes = G1Element::FromMessage(Bytes(vecHash), vecHash.data(), vecHash.size());
         REQUIRE(g1MessageVector == g1MessageBytes);
 
         G2Element g2MessageVector = G2Element::FromMessage(vecHash, vecHash.data(), vecHash.size());
-        G2Element g2MessageBytes = G2Element::FromMessage(Bytes{vecHash}, vecHash.data(), vecHash.size());
+        G2Element g2MessageBytes = G2Element::FromMessage(Bytes(vecHash), vecHash.data(), vecHash.size());
         REQUIRE(g2MessageVector == g2MessageBytes);
 
         G1Element g1_1 = pk1.GetG1Element();
@@ -971,14 +971,14 @@ TEST_CASE("Advanced") {
         G1Element g1_3 = pk3.GetG1Element();
 
         G2Element g2BasicSignVector1 = BasicSchemeMPL().Sign(pk1, vecHash);
-        G2Element g2BasicSignBytes1 = BasicSchemeMPL().Sign(pk1, Bytes{vecHash});
+        G2Element g2BasicSignBytes1 = BasicSchemeMPL().Sign(pk1, Bytes(vecHash));
         REQUIRE(g2BasicSignVector1 == g2BasicSignBytes1);
-        G2Element g2BasicSign2 = BasicSchemeMPL().Sign(pk2, Bytes{vecHash});
-        G2Element g2BasicSign3 = BasicSchemeMPL().Sign(pk3, Bytes{vecG2Element});
+        G2Element g2BasicSign2 = BasicSchemeMPL().Sign(pk2, Bytes(vecHash));
+        G2Element g2BasicSign3 = BasicSchemeMPL().Sign(pk3, Bytes(vecG2Element));
         REQUIRE(g2BasicSignVector1 != g2BasicSign2);
 
-        REQUIRE(BasicSchemeMPL().Verify(Bytes{g1_1.Serialize()}, Bytes{vecHash}, Bytes{g2BasicSignVector1.Serialize()}));
-        REQUIRE(BasicSchemeMPL().Verify(g1_1, Bytes{vecHash}, g2BasicSignVector1));
+        REQUIRE(BasicSchemeMPL().Verify(Bytes(g1_1.Serialize()), Bytes(vecHash), Bytes(g2BasicSignVector1.Serialize())));
+        REQUIRE(BasicSchemeMPL().Verify(g1_1, Bytes(vecHash), g2BasicSignVector1));
 
         vector<vector<uint8_t>> vecG1Vector = {g1_1.Serialize(), g1_3.Serialize()};
         vector<vector<uint8_t>> vecG2Vector = {g2BasicSignVector1.Serialize(), g2BasicSign3.Serialize()};
@@ -990,19 +990,19 @@ TEST_CASE("Advanced") {
 
         REQUIRE(BasicSchemeMPL().AggregateVerify(vector<Bytes>{vecG1Vector.begin(), vecG1Vector.end()},
                                                  vector<Bytes>{vecHashes.begin(), vecHashes.end()},
-                                                 Bytes{aggVector}));
+                                                 Bytes(aggVector)));
         REQUIRE(BasicSchemeMPL().AggregateVerify({g1_1, g1_3},
                                                  vector<Bytes>{vecHashes.begin(), vecHashes.end()},
                                                  G2Element::FromByteVector(aggVector)));
 
         G2Element g2AugSignVector1 = AugSchemeMPL().Sign(pk1, vecHash);
-        G2Element g2AugSignBytes1 = AugSchemeMPL().Sign(pk1, Bytes{vecHash});
+        G2Element g2AugSignBytes1 = AugSchemeMPL().Sign(pk1, Bytes(vecHash));
         G2Element g2AugSign2 = AugSchemeMPL().Sign(pk2, vecG2Element);
         REQUIRE(g2AugSignVector1 == g2AugSignBytes1);
         REQUIRE(g2AugSignVector1 != g2AugSign2);
 
-        REQUIRE(AugSchemeMPL().Verify(Bytes{g1_1.Serialize()}, Bytes{vecHash}, Bytes{g2AugSignVector1.Serialize()}));
-        REQUIRE(AugSchemeMPL().Verify(g1_1, Bytes{vecHash}, g2AugSignVector1));
+        REQUIRE(AugSchemeMPL().Verify(Bytes(g1_1.Serialize()), Bytes(vecHash), Bytes(g2AugSignVector1.Serialize())));
+        REQUIRE(AugSchemeMPL().Verify(g1_1, Bytes(vecHash), g2AugSignVector1));
 
         vector<vector<uint8_t>> vecG1AugVector = {g1_1.Serialize(), g1_2.Serialize()};
         vector<vector<uint8_t>> vecG2AugVector = {g2AugSignVector1.Serialize(), g2AugSign2.Serialize()};
@@ -1013,22 +1013,22 @@ TEST_CASE("Advanced") {
 
         REQUIRE(AugSchemeMPL().AggregateVerify(vector<Bytes>{vecG1AugVector.begin(), vecG1AugVector.end()},
                                                  vector<Bytes>{vecHashes.begin(), vecHashes.end()},
-                                                 Bytes{aggAugVector}));
+                                                 Bytes(aggAugVector)));
         REQUIRE(AugSchemeMPL().AggregateVerify({g1_1, g1_2},
                                                  vector<Bytes>{vecHashes.begin(), vecHashes.end()},
                                                  G2Element::FromByteVector(aggAugVector)));
 
         G2Element proof = PopSchemeMPL().PopProve(pk1);
         REQUIRE(PopSchemeMPL().PopVerify(g1_1, proof));
-        REQUIRE(PopSchemeMPL().PopVerify(Bytes{g1_1.Serialize()}, Bytes{proof.Serialize()}));
+        REQUIRE(PopSchemeMPL().PopVerify(Bytes(g1_1.Serialize()), Bytes(proof.Serialize())));
 
         G2Element g2Pop1 = PopSchemeMPL().Sign(pk1, vecHash);
         G2Element g2Pop2 = PopSchemeMPL().Sign(pk2, vecHash);
         G2Element g2PopAgg = PopSchemeMPL().Aggregate({g2Pop1, g2Pop2});
         vecG1Vector = {g1_1.Serialize(), g1_2.Serialize()};
-        REQUIRE(PopSchemeMPL().FastAggregateVerify({g1_1, g1_2}, Bytes{vecHash}, g2PopAgg));
+        REQUIRE(PopSchemeMPL().FastAggregateVerify({g1_1, g1_2}, Bytes(vecHash), g2PopAgg));
         REQUIRE(PopSchemeMPL().FastAggregateVerify(vector<Bytes>{vecG1Vector.begin(), vecG1Vector.end()},
-                                                   Bytes{vecHash}, Bytes{g2PopAgg.Serialize()}));
+                                                   Bytes(vecHash), Bytes(g2PopAgg.Serialize())));
     }
 }
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -100,21 +100,21 @@ TEST_CASE("class PrivateKey") {
         PrivateKey pk1 = PrivateKey::FromByteVector(getRandomSeed(), true);
         pk1.Serialize(buffer);
         REQUIRE(memcmp(buffer, pk1.Serialize().data(), PrivateKey::PRIVATE_KEY_SIZE) == 0);
-        PrivateKey pk2 = PrivateKey:: FromBytes({buffer, PrivateKey::PRIVATE_KEY_SIZE}, true);
+        PrivateKey pk2 = PrivateKey:: FromBytes(Bytes(buffer, PrivateKey::PRIVATE_KEY_SIZE), true);
         REQUIRE(pk1 == pk2);
-        REQUIRE_THROWS(PrivateKey::FromBytes({buffer, PrivateKey::PRIVATE_KEY_SIZE - 1}, true));
-        REQUIRE_THROWS(PrivateKey::FromBytes({buffer, PrivateKey::PRIVATE_KEY_SIZE + 1}, true));
-        REQUIRE_NOTHROW(PrivateKey::FromBytes({buffer, PrivateKey::PRIVATE_KEY_SIZE}, true));
+        REQUIRE_THROWS(PrivateKey::FromBytes(Bytes(buffer, PrivateKey::PRIVATE_KEY_SIZE - 1), true));
+        REQUIRE_THROWS(PrivateKey::FromBytes(Bytes(buffer, PrivateKey::PRIVATE_KEY_SIZE + 1), true));
+        REQUIRE_NOTHROW(PrivateKey::FromBytes(Bytes(buffer, PrivateKey::PRIVATE_KEY_SIZE), true));
         bn_t order;
         bn_new(order);
         g1_get_ord(order);
         bn_write_bin(buffer, PrivateKey::PRIVATE_KEY_SIZE, order);
-        REQUIRE_NOTHROW(PrivateKey::FromBytes({buffer, PrivateKey::PRIVATE_KEY_SIZE}, false));
-        REQUIRE_NOTHROW(PrivateKey::FromBytes({buffer, PrivateKey::PRIVATE_KEY_SIZE}, true));
+        REQUIRE_NOTHROW(PrivateKey::FromBytes(Bytes(buffer, PrivateKey::PRIVATE_KEY_SIZE), false));
+        REQUIRE_NOTHROW(PrivateKey::FromBytes(Bytes(buffer, PrivateKey::PRIVATE_KEY_SIZE), true));
         bn_add(order, order, order);
         bn_write_bin(buffer, PrivateKey::PRIVATE_KEY_SIZE, order);
-        REQUIRE_THROWS(PrivateKey::FromBytes({buffer, PrivateKey::PRIVATE_KEY_SIZE}, false));
-        REQUIRE_NOTHROW(PrivateKey::FromBytes({buffer, PrivateKey::PRIVATE_KEY_SIZE}, true));
+        REQUIRE_THROWS(PrivateKey::FromBytes(Bytes(buffer, PrivateKey::PRIVATE_KEY_SIZE), false));
+        REQUIRE_NOTHROW(PrivateKey::FromBytes(Bytes(buffer, PrivateKey::PRIVATE_KEY_SIZE), true));
     }
     SECTION("keydata checks") {
         PrivateKey pk1 = PrivateKey::FromByteVector(getRandomSeed(), true);
@@ -303,7 +303,7 @@ TEST_CASE("IETF test vectors") {
         string sig1BasicHex = "96ba34fac33c7f129d602a0bc8a3d43f9abc014eceaab7359146b4b150e57b808645738f35671e9e10e0d862a30cab70074eb5831d13e6a5b162d01eebe687d0164adbd0a864370a7c222a2768d7704da254f1bf1823665bc2361f9dd8c00e99";
         string sk = "0x0101010101010101010101010101010101010101010101010101010101010101";
         vector<uint8_t> msg = {3, 1, 4, 1, 5, 9};
-        auto skobj = PrivateKey::FromBytes({Util::HexToBytes(sk)});
+        auto skobj = PrivateKey::FromBytes(Bytes(Util::HexToBytes(sk)));
         G2Element sig = BasicSchemeMPL().Sign(skobj, msg);
         vector<uint8_t> sig1;
         for (const uint8_t byte : Util::HexToBytes(sig1BasicHex)) {
@@ -460,7 +460,7 @@ TEST_CASE("Error handling")
         uint8_t* skData = Util::SecAlloc<uint8_t>(G2Element::SIZE);
         sk1.Serialize(skData);
         skData[0] = 255;
-        REQUIRE_THROWS(PrivateKey::FromBytes({skData, PrivateKey::PRIVATE_KEY_SIZE}));
+        REQUIRE_THROWS(PrivateKey::FromBytes(Bytes(skData, PrivateKey::PRIVATE_KEY_SIZE)));
         Util::SecFree(skData);
     }
 
@@ -546,7 +546,7 @@ TEST_CASE("Signature tests")
 
         uint8_t skBytes[PrivateKey::PRIVATE_KEY_SIZE];
         sk2.Serialize(skBytes);
-        PrivateKey sk4 = PrivateKey::FromBytes({skBytes, PrivateKey::PRIVATE_KEY_SIZE});
+        PrivateKey sk4 = PrivateKey::FromBytes(Bytes(skBytes, PrivateKey::PRIVATE_KEY_SIZE));
 
         G1Element pk2 = G1Element(pk1);
         G2Element sig1 = BasicSchemeMPL().Sign(sk4, message1);
@@ -606,19 +606,19 @@ TEST_CASE("Signature tests")
 
         uint8_t* skData = Util::SecAlloc<uint8_t>(G2Element::SIZE);
         sk1.Serialize(skData);
-        PrivateKey sk2 = PrivateKey::FromBytes({skData, PrivateKey::PRIVATE_KEY_SIZE});
+        PrivateKey sk2 = PrivateKey::FromBytes(Bytes(skData, PrivateKey::PRIVATE_KEY_SIZE));
         REQUIRE(sk1 == sk2);
 
         auto pkData = pk1.Serialize();
 
-        G1Element pk2 = G1Element::FromBytes({pkData});
+        G1Element pk2 = G1Element::FromBytes(Bytes(pkData));
         REQUIRE(pk1 == pk2);
 
         G2Element sig1 = BasicSchemeMPL().Sign(sk1, message1);
 
         auto sigData = sig1.Serialize();
 
-        G2Element sig2 = G2Element::FromBytes({sigData});
+        G2Element sig2 = G2Element::FromBytes(Bytes(sigData));
         REQUIRE(sig1 == sig2);
 
         REQUIRE(BasicSchemeMPL().Verify(pk2, message1, sig2));

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -29,11 +29,11 @@ class Bytes {
     const size_t nSize;
 
 public:
-    Bytes(const uint8_t* pDataIn, const size_t nSizeIn)
+    explicit Bytes(const uint8_t* pDataIn, const size_t nSizeIn)
         : pData(pDataIn), nSize(nSizeIn)
     {
     }
-    Bytes(const std::vector<uint8_t>& vecBytes)
+    explicit Bytes(const std::vector<uint8_t>& vecBytes)
         : pData(vecBytes.data()), nSize(vecBytes.size())
     {
     }


### PR DESCRIPTION
Based on #171 and #172