### PR TITLE
Ensure relic_core_initializer call is thread-aware

### DIFF
--- a/src/bls.cpp
+++ b/src/bls.cpp
@@ -52,7 +52,12 @@ bool BLS::Init()
     SetSecureAllocator(malloc, free);
 #endif
 
+#if MULTI != RELIC_NONE
     core_set_thread_initializer(relic_core_initializer, nullptr);
+#else
+    relic_core_initializer(nullptr);
+#endif
+    
     return true;
 }
 


### PR DESCRIPTION
## Description

`core_set_thread_initializer` is only defined if macro `MULTI != RELIC_NONE` evaluates true but `bls.cpp` takes the presence of `core_set_thread_initializer` for granted. This resolves that issue.

Tested on `Darwin Kernel Version 20.3.0: Thu Jan 21 00:07:06 PST 2021; root:xnu-7195.81.3~1/RELEASE_X86_64`

## Resources

* https://github.com/dashpay/bls-signatures/pull/13 ("Don't call core_set_thread_initializer if not defined" by kittywhiskers)

* https://github.com/dashpay/bls-signatures/commit/f208c6764a89959890f3f7970812eb27cd6bba00 ("src|test: Fix multithreading availability checks" by @xdustinface)