### PR TITLE
git|contrib: Drop relic submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "contrib/pybind11"]
 	path = contrib/pybind11
 	url = https://github.com/pybind/pybind11.git
-[submodule "contrib/relic"]
-	path = contrib/relic
-	url = https://github.com/Chia-Network/relic


### PR DESCRIPTION
This is just confusing because its the `Chia-Network` fork and its not really related to the relic version that cmake pulls.