### PR TITLE
Update to RELIC's change from COMP to CFLAGS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ ENDIF()
 set(STBIN "OFF" CACHE STRING "")
 
 set(FP_METHD "INTEG;INTEG;INTEG;MONTY;LOWER;SLIDE" CACHE STRING "")
-set(COMP "-O3 -funroll-loops -fomit-frame-pointer" CACHE STRING "")
+set(CFLAGS "-O3 -funroll-loops -fomit-frame-pointer" CACHE STRING "")
 set(FP_PMERS "off" CACHE STRING "")
 set(FPX_METHD "INTEG;INTEG;LAZYR" CACHE STRING "")
 set(EP_PLAIN "off" CACHE STRING "")


### PR DESCRIPTION
Quick update to reflect that RELIC changed naming of a variable to be closer to CMake conventions.