### PR TITLE
use int instead of double for counting test iterations

### DIFF
--- a/src/test-bench.cpp
+++ b/src/test-bench.cpp
@@ -30,13 +30,13 @@ using namespace bls;
 
 void benchSigs() {
     string testName = "Signing";
-    double numIters = 5000;
+    const int numIters = 5000;
     PrivateKey sk = AugSchemeMPL().KeyGen(getRandomSeed());
     vector<uint8_t> message1 = sk.GetG1Element().Serialize();
 
     auto start = startStopwatch();
 
-    for (size_t i = 0; i < numIters; i++) {
+    for (int i = 0; i < numIters; i++) {
         AugSchemeMPL().Sign(sk, message1);
     }
     endStopwatch(testName, start, numIters);
@@ -44,13 +44,13 @@ void benchSigs() {
 
 void benchVerification() {
     string testName = "Verification";
-    double numIters = 10000;
+    const int numIters = 10000;
     PrivateKey sk = AugSchemeMPL().KeyGen(getRandomSeed());
     G1Element pk = sk.GetG1Element();
 
     std::vector<G2Element> sigs;
 
-    for (size_t i = 0; i < numIters; i++) {
+    for (int i = 0; i < numIters; i++) {
         uint8_t message[4];
         Util::IntToFourBytes(message, i);
         vector<uint8_t> messageBytes(message, message + 4);
@@ -58,7 +58,7 @@ void benchVerification() {
     }
 
     auto start = startStopwatch();
-    for (size_t i = 0; i < numIters; i++) {
+    for (int i = 0; i < numIters; i++) {
         uint8_t message[4];
         Util::IntToFourBytes(message, i);
         vector<uint8_t> messageBytes(message, message + 4);
@@ -69,13 +69,13 @@ void benchVerification() {
 }
 
 void benchBatchVerification() {
-    double numIters = 100000;
+    const int numIters = 100000;
 
     vector<G2Element> sigs;
     vector<G1Element> pks;
     vector<vector<uint8_t>> ms;
 
-    for (size_t i = 0; i < numIters; i++) {
+    for (int i = 0; i < numIters; i++) {
         uint8_t message[4];
         Util::IntToFourBytes(message, i);
         vector<uint8_t> messageBytes(message, message + 4);
@@ -97,14 +97,14 @@ void benchBatchVerification() {
 }
 
 void benchFastAggregateVerification() {
-    double numIters = 5000;
+    const int numIters = 5000;
 
     vector<G2Element> sigs;
     vector<G1Element> pks;
     vector<uint8_t> message = {1, 2, 3, 4, 5, 6, 7, 8};
     vector<G2Element> pops;
 
-    for (size_t i = 0; i < numIters; i++) {
+    for (int i = 0; i < numIters; i++) {
         PrivateKey sk = PopSchemeMPL().KeyGen(getRandomSeed());
         G1Element pk = sk.GetG1Element();
         sigs.push_back(PopSchemeMPL().Sign(sk, message));
@@ -118,7 +118,7 @@ void benchFastAggregateVerification() {
 
 
     start = startStopwatch();
-    for (size_t i = 0; i < numIters; i++) {
+    for (int i = 0; i < numIters; i++) {
         bool ok = PopSchemeMPL().PopVerify(pks[i], pops[i]);
         ASSERT(ok);
     }

--- a/src/test-utils.hpp
+++ b/src/test-utils.hpp
@@ -30,7 +30,7 @@ std::chrono::time_point<std::chrono::steady_clock> startStopwatch() {
 
 void endStopwatch(string testName,
                   std::chrono::time_point<std::chrono::steady_clock> start,
-                  double numIters) {
+                  int numIters) {
     auto end = std::chrono::steady_clock::now();
     auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             end - start);
@@ -38,7 +38,7 @@ void endStopwatch(string testName,
     cout << endl << testName << endl;
     cout << "Total: " << numIters << " runs in " << now_ms.count()
          << " ms" << endl;
-    cout << "Avg: " << now_ms.count() / numIters
+    cout << "Avg: " << now_ms.count() / static_cast<double>(numIters)
          << " ms" << endl;
 }
 


### PR DESCRIPTION
I don't think there's a good reason to use `double` to count iterations. It's inherently an integer.