### PR TITLE
avoid copying of public keys, messages in batch validation

### DIFF
--- a/src/schemes.hpp
+++ b/src/schemes.hpp
@@ -26,13 +26,12 @@
 
 #include "elements.hpp"
 #include "privatekey.hpp"
+#include "util.hpp"
 
 using std::vector;
 
 // These are all MPL schemes
 namespace bls {
-
-class Bytes;
 
 class CoreMPL {
 
@@ -83,8 +82,8 @@ public:
                                  const vector<vector<uint8_t>> &messages,
                                  const G2Element &signature);
 
-     virtual bool AggregateVerify(const vector<G1Element>& pubkeys,
-                                  const vector<Bytes>& messages,
+     virtual bool AggregateVerify(span<G1Element const> pubkeys,
+                                  span<Bytes const> messages,
                                   const G2Element& signature);
 
     PrivateKey DeriveChildSk(const PrivateKey& sk, uint32_t index);
@@ -112,8 +111,8 @@ public:
                          const vector<vector<uint8_t>> &messages,
                          const G2Element &signature) override;
 
-    bool AggregateVerify(const vector<G1Element>& pubkeys,
-                         const vector<Bytes>& messages,
+    bool AggregateVerify(span<G1Element const> pubkeys,
+                         span<Bytes const> messages,
                          const G2Element& signature) override;
 };
 
@@ -165,8 +164,8 @@ public:
                          const vector<vector<uint8_t>> &messages,
                          const G2Element &signature) override;
 
-    bool AggregateVerify(const vector<G1Element>& pubkeys,
-                         const vector<Bytes>& messages,
+    bool AggregateVerify(span<G1Element const> pubkeys,
+                         span<Bytes const> messages,
                          const G2Element& signature) override;
 };
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -360,8 +360,8 @@ TEST_CASE("Chia test vectors") {
             "4a94d195d7b0231d4afcf06f27f0cc4d3c72162545c240de7d5034a7ef3a2a03c0159de982fb"
             "c2e7790aeb455e27beae91d64e077c70b5506dea3");
 
-        REQUIRE(BasicSchemeMPL().AggregateVerify({pk1, pk2}, vector<vector<uint8_t>>{message1, message2}, aggSig1));
-        REQUIRE(!BasicSchemeMPL().AggregateVerify({pk1, pk2}, vector<vector<uint8_t>>{message1, message2}, sig1));
+        REQUIRE(BasicSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, vector<vector<uint8_t>>{message1, message2}, aggSig1));
+        REQUIRE(!BasicSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, vector<vector<uint8_t>>{message1, message2}, sig1));
         REQUIRE(!BasicSchemeMPL().Verify(pk1, message1, sig2));
         REQUIRE(!BasicSchemeMPL().Verify(pk1, message2, sig1));
 
@@ -375,7 +375,7 @@ TEST_CASE("Chia test vectors") {
 
         G2Element aggSig2 = BasicSchemeMPL().Aggregate({sig3, sig4, sig5});
 
-        REQUIRE(BasicSchemeMPL().AggregateVerify({pk1, pk1, pk2}, vector<vector<uint8_t>>{message3, message4, message5}, aggSig2));
+        REQUIRE(BasicSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk1, pk2}, vector<vector<uint8_t>>{message3, message4, message5}, aggSig2));
         REQUIRE(
             Util::HexStr(aggSig2.Serialize()) ==
             "a0b1378d518bea4d1100adbc7bdbc4ff64f2c219ed6395cd36fe5d2aa44a4b8e710b607afd9"
@@ -410,7 +410,7 @@ TEST_CASE("Chia test vectors") {
         G2Element aggSigR = AugSchemeMPL().Aggregate({sig3, sig4, sig5});
         G2Element aggSig = AugSchemeMPL().Aggregate({aggSigL, aggSigR, sig6});
 
-        REQUIRE(AugSchemeMPL().AggregateVerify({pk1, pk2, pk2, pk1, pk1, pk1}, vector<vector<uint8_t>>{message1, message2, message1, message3, message1, message4}, aggSig));
+        REQUIRE(AugSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2, pk2, pk1, pk1, pk1}, vector<vector<uint8_t>>{message1, message2, message1, message3, message1, message4}, aggSig));
 
         REQUIRE(
             Util::HexStr(aggSig.Serialize()) ==
@@ -643,7 +643,7 @@ TEST_CASE("Signature tests")
         G2Element sig2 = BasicSchemeMPL().Sign(sk2, message);
 
         G2Element aggSig = BasicSchemeMPL().Aggregate({sig1, sig2});
-        REQUIRE(BasicSchemeMPL().AggregateVerify({pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig) == false);
+        REQUIRE(BasicSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig) == false);
     }
 
     SECTION("Should verify aggregate with same message under AugScheme/PopScheme")
@@ -663,12 +663,12 @@ TEST_CASE("Signature tests")
         G2Element sig1Aug = AugSchemeMPL().Sign(sk1, message);
         G2Element sig2Aug = AugSchemeMPL().Sign(sk2, message);
         G2Element aggSigAug = AugSchemeMPL().Aggregate({sig1Aug, sig2Aug});
-        REQUIRE(AugSchemeMPL().AggregateVerify({pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSigAug));
+        REQUIRE(AugSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSigAug));
 
         G2Element sig1Pop = PopSchemeMPL().Sign(sk1, message);
         G2Element sig2Pop = PopSchemeMPL().Sign(sk2, message);
         G2Element aggSigPop = PopSchemeMPL().Aggregate({sig1Pop, sig2Pop});
-        REQUIRE(PopSchemeMPL().AggregateVerify({pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSigPop));
+        REQUIRE(PopSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSigPop));
     }
 
     SECTION("Should Aug aggregate many G2Elements, diff message")
@@ -754,8 +754,8 @@ TEST_CASE("Agg sks") {
         REQUIRE(BasicSchemeMPL().Verify(aggPubKey, message, aggSig2));
 
         // Verify aggregate with both keys (Fails since not distinct)
-        REQUIRE(BasicSchemeMPL().AggregateVerify({pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig) == false);
-        REQUIRE(BasicSchemeMPL().AggregateVerify({pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig2) == false);
+        REQUIRE(BasicSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig) == false);
+        REQUIRE(BasicSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, vector<vector<uint8_t>>{message, message}, aggSig2) == false);
 
         // Try the same with distinct message, and same sk
         vector<uint8_t> message2 = {200, 29, 54, 8, 9, 29, 155, 55};
@@ -777,7 +777,7 @@ TEST_CASE("Agg sks") {
         REQUIRE(pkFinal != aggPubKey);
 
         // Cannot verify with aggPubKey (since we have multiple messages)
-        REQUIRE(BasicSchemeMPL().AggregateVerify({aggPubKey, pk2}, vector<vector<uint8_t>>{message, message2}, aggSigFinal));
+        REQUIRE(BasicSchemeMPL().AggregateVerify(std::vector<G1Element>{aggPubKey, pk2}, vector<vector<uint8_t>>{message, message2}, aggSigFinal));
     }
 }
 
@@ -887,7 +887,7 @@ TEST_CASE("Advanced") {
         // Signatures can be noninteractively combined by anyone
         G2Element aggSig = AugSchemeMPL().Aggregate({sig1, sig2});
 
-        REQUIRE(AugSchemeMPL().AggregateVerify({pk1, pk2}, vector<vector<uint8_t>>{message, message2}, aggSig));
+        REQUIRE(AugSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, vector<vector<uint8_t>>{message, message2}, aggSig));
 
         seed[0] = 3;
         PrivateKey sk3 = AugSchemeMPL().KeyGen(seed);
@@ -899,7 +899,7 @@ TEST_CASE("Advanced") {
         // Arbitrary trees of aggregates
         G2Element aggSigFinal = AugSchemeMPL().Aggregate({aggSig, sig3});
 
-        REQUIRE(AugSchemeMPL().AggregateVerify({pk1, pk2, pk3}, vector<vector<uint8_t>>{message, message2, message3}, aggSigFinal));
+        REQUIRE(AugSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2, pk3}, vector<vector<uint8_t>>{message, message2, message3}, aggSigFinal));
 
         // If the same message is signed, you can use Proof of Posession (PopScheme) for efficiency
         // A proof of possession MUST be passed around with the PK to ensure security.
@@ -991,7 +991,7 @@ TEST_CASE("Advanced") {
         REQUIRE(BasicSchemeMPL().AggregateVerify(vector<Bytes>{vecG1Vector.begin(), vecG1Vector.end()},
                                                  vector<Bytes>{vecHashes.begin(), vecHashes.end()},
                                                  Bytes(aggVector)));
-        REQUIRE(BasicSchemeMPL().AggregateVerify({g1_1, g1_3},
+        REQUIRE(BasicSchemeMPL().AggregateVerify(std::vector<G1Element>{g1_1, g1_3},
                                                  vector<Bytes>{vecHashes.begin(), vecHashes.end()},
                                                  G2Element::FromByteVector(aggVector)));
 
@@ -1014,7 +1014,7 @@ TEST_CASE("Advanced") {
         REQUIRE(AugSchemeMPL().AggregateVerify(vector<Bytes>{vecG1AugVector.begin(), vecG1AugVector.end()},
                                                  vector<Bytes>{vecHashes.begin(), vecHashes.end()},
                                                  Bytes(aggAugVector)));
-        REQUIRE(AugSchemeMPL().AggregateVerify({g1_1, g1_2},
+        REQUIRE(AugSchemeMPL().AggregateVerify(std::vector<G1Element>{g1_1, g1_2},
                                                  vector<Bytes>{vecHashes.begin(), vecHashes.end()},
                                                  G2Element::FromByteVector(aggAugVector)));
 
@@ -1068,7 +1068,7 @@ TEST_CASE("Schemes") {
 
         G2Element aggsig = BasicSchemeMPL().Aggregate({sig1, sig2});
         vector<uint8_t> aggsigv = BasicSchemeMPL().Aggregate(vector<vector<uint8_t>>{sig1v, sig2v});
-        REQUIRE(BasicSchemeMPL().AggregateVerify({pk1, pk2}, msgs, aggsig));
+        REQUIRE(BasicSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, msgs, aggsig));
         REQUIRE(BasicSchemeMPL().AggregateVerify({pk1v, pk2v}, msgs, aggsigv));
     }
 
@@ -1107,7 +1107,7 @@ TEST_CASE("Schemes") {
 
         G2Element aggsig = AugSchemeMPL().Aggregate({sig1, sig2});
         vector<uint8_t> aggsigv = AugSchemeMPL().Aggregate(vector<vector<uint8_t>>{sig1v, sig2v});
-        REQUIRE(AugSchemeMPL().AggregateVerify({pk1, pk2}, msgs, aggsig));
+        REQUIRE(AugSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, msgs, aggsig));
         REQUIRE(AugSchemeMPL().AggregateVerify({pk1v, pk2v}, msgs, aggsigv));
     }
 
@@ -1146,7 +1146,7 @@ TEST_CASE("Schemes") {
 
         G2Element aggsig = PopSchemeMPL().Aggregate({sig1, sig2});
         vector<uint8_t> aggsigv = PopSchemeMPL().Aggregate(vector<vector<uint8_t>>{sig1v, sig2v});
-        REQUIRE(PopSchemeMPL().AggregateVerify({pk1, pk2}, msgs, aggsig));
+        REQUIRE(PopSchemeMPL().AggregateVerify(std::vector<G1Element>{pk1, pk2}, msgs, aggsig));
         REQUIRE(PopSchemeMPL().AggregateVerify({pk1v, pk2v}, msgs, aggsigv));
 
         // PopVerify

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -19,32 +19,37 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <type_traits>
 
 namespace bls {
 
 class BLS;
 
-class Bytes {
-    const uint8_t* pData;
-    const size_t nSize;
+template <typename T>
+class span {
+    T* pData;
+    size_t nSize;
 
 public:
-    explicit Bytes(const uint8_t* pDataIn, const size_t nSizeIn)
+    explicit span(const T* pDataIn, const size_t nSizeIn)
         : pData(pDataIn), nSize(nSizeIn)
     {
     }
-    explicit Bytes(const std::vector<uint8_t>& vecBytes)
-        : pData(vecBytes.data()), nSize(vecBytes.size())
+
+    span(const std::vector<typename std::remove_const<T>::type>& cont)
+        : pData(cont.data()), nSize(cont.size())
     {
     }
 
-    inline const uint8_t* begin() const { return pData; }
-    inline const uint8_t* end() const { return pData + nSize; }
+    inline const T* begin() const { return pData; }
+    inline const T* end() const { return pData + nSize; }
 
     inline size_t size() const { return nSize; }
 
-    const uint8_t& operator[](const int nIndex) const { return pData[nIndex]; }
+    const T& operator[](const int nIndex) const { return pData[nIndex]; }
 };
+
+using Bytes = span<uint8_t const>;
 
 class Util {
  public:


### PR DESCRIPTION
There are two main aspects of this patch:

1. modernize the interface a bit to take `span` rather than `std::vector`. For now, use our own `span` type, but this could use GSL or `std::span` in the future. The main motivation for this is to allow passing ranges of values without having to first copy them into a `std::vector`

2. The part of `AggregateVerify()` that builds a new list of messages where the serialized public key is prepended is made a little bit more efficient, by putting all the messages into a single allocation. This is possible because using `span` doesn't require the messages to be allocated in a specific way.

There is a small speed improvement (1.45%). I had been hoping for more but I think it's worth it partly because it enables more efficient use of the API.

current `main` branch:
```
Batch verification
Total: 100000 runs in 141194 ms
Avg: 1.41194 ms
```

This patch:
```
Batch verification
Total: 100000 runs in 139153 ms
Avg: 1.39153 ms
```