### PR TITLE
remove redundant validation checks

### DIFF
--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -88,6 +88,7 @@ G1Element G1Element::FromMessage(const Bytes& message,
 {
     G1Element ans;
     ep_map_dst(ans.p, message.begin(), (int)message.size(), dst, dst_len);
+    BLS::CheckRelicErrors();
     assert(ans.IsValid());
     return ans;
 }
@@ -279,6 +280,7 @@ G2Element G2Element::FromMessage(const Bytes& message,
 {
     G2Element ans;
     ep2_map_dst(ans.q, message.begin(), (int)message.size(), dst, dst_len);
+    BLS::CheckRelicErrors();
     assert(ans.IsValid());
     return ans;
 }

--- a/src/elements.hpp
+++ b/src/elements.hpp
@@ -50,6 +50,7 @@ public:
                                  int dst_len);
     static G1Element Generator();
 
+    bool IsValid() const;
     void CheckValid() const;
     void ToNative(g1_t output) const;
     G1Element Negate() const;
@@ -87,6 +88,7 @@ public:
                                  int dst_len);
     static G2Element Generator();
 
+    bool IsValid() const;
     void CheckValid() const;
     void ToNative(g2_t output) const;
     G2Element Negate() const;


### PR DESCRIPTION
`ep_map_dst()` and `ep2_map_dst()` ought to return valid points, the validation of their output is redundant (and expensive).

These are my timings before and after this change:

```
Batch verification
Total: 100000 runs in 133637 ms
Avg: 1.33637 ms
```

```
Batch verification
Total: 100000 runs in 73739 ms
Avg: 0.73739 ms
```