### PR TITLE
relic's main branch is "main"

### DIFF
--- a/.github/workflows/relic-nightly.yml
+++ b/.github/workflows/relic-nightly.yml
@@ -24,12 +24,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Ubuntu build C++ and test Relic at origin/master
+    - name: Ubuntu build C++ and test Relic at origin/main
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        echo "Relic origin/master commit:"
+        echo "Relic origin/main commit:"
         curl -H "application/vnd.github.v3.sha" \
-        https://api.github.com/repos/relic-toolkit/relic/commits/master | \
+        https://api.github.com/repos/relic-toolkit/relic/commits/main | \
         head -10
         sudo apt-get update
         sudo apt-get install snap -y
@@ -48,7 +48,7 @@ jobs:
         cd ..
         echo "Setting libsodium to static compile."
         export CIBUILDWHEEL=1
-        export RELIC_MASTER=1
+        export RELIC_MAIN=1
         mkdir -p build
         cd build
         cmake ../

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,8 @@ set (CMAKE_CXX_STANDARD 17)
 # CMake 3.14+
 include(FetchContent)
 
-if (DEFINED ENV{RELIC_MASTER})
-  set(RELIC_GIT_TAG "origin/master")
+if (DEFINED ENV{RELIC_MAIN})
+  set(RELIC_GIT_TAG "origin/main")
 else ()
   set(RELIC_GIT_TAG "03a7c3b7fa43c0da6f3720e341f7d4f6a6d6f21e")
 endif ()

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -21,7 +21,6 @@
 extern "C" {
 #include "relic.h"
 }
-#include "relic_test.h"
 #include "test-utils.hpp"
 using std::cout;
 using std::endl;


### PR DESCRIPTION
It seems it used to be `master`.

`relic_test.h` now defines a macro called `TEST_CASE` which conflicts with catch's macro with the same name. It doesn't seem like we need anything out of that header though.