### PR TITLE
Simplify IsValid()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 if (DEFINED ENV{RELIC_MAIN})
   set(RELIC_GIT_TAG "origin/main")
 else ()
-  set(RELIC_GIT_TAG "03a7c3b7fa43c0da6f3720e341f7d4f6a6d6f21e")
+  set(RELIC_GIT_TAG "1885ae3b681c423c72b65ce1fe70910142cf941c")
 endif ()
 
 message(STATUS "Relic will be built from: ${RELIC_GIT_TAG}")

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -106,17 +106,8 @@ bool G1Element::IsValid() const {
     // https://github.com/relic-toolkit/relic/commit/f3be2babb955cf9f82743e0ae5ef265d3da6c02b
     if (g1_is_infty((g1_st*)p) == 1)
         return true;
-    if (g1_is_valid((g1_st*)p) == 0)
-        return false;
 
-    // check if inside subgroup
-    bn_t order;
-    bn_new(order);
-    g1_get_ord(order);
-
-    const G1Element point = *this * order;
-    bn_free(order);
-    return point == G1Element();
+    return g1_is_valid((g1_st*)p);
 }
 
 void G1Element::CheckValid() const {
@@ -298,17 +289,8 @@ bool G2Element::IsValid() const {
     // https://github.com/relic-toolkit/relic/commit/f3be2babb955cf9f82743e0ae5ef265d3da6c02b
     if (g2_is_infty((g2_st*)q) == 1)
         return true;
-    if (g2_is_valid((g2_st*)q) == 0)
-        return false;
 
-    // check if inside subgroup
-    bn_t order;
-    bn_new(order);
-    g2_get_ord(order);
-
-    G2Element point = *this * order;
-    bn_free(order);
-    return point == G2Element();
+    return g2_is_valid((g2_st*)q);
 }
 
 void G2Element::CheckValid() const {


### PR DESCRIPTION
New versions of relic includes an optimized subgroup check for G1 and G2. Not only do we not need to do our own subgroup check, but we also get a good speedup by just upgrading relic.

In `main` right now, our `IsValid()` call is dominated by the cost to `g1_is_valid()` and `g2_is_valid()` calls (>90% of the time is spent in those calls).

Here's a comparison between just the current version of relic vs. head of `main` (both with this patch to `IsValid()`):

```
Public key validation
Total: 100000 runs in 33414 ms
Avg: 0.33414 ms

Signature validation
Total: 100000 runs in 68799 ms
Avg: 0.68799 ms
```

```
Public key validation
Total: 100000 runs in 14181 ms
Avg: 0.14181 ms

Signature validation
Total: 100000 runs in 18321 ms
Avg: 0.18321 ms
```