### PR TITLE
Fix support to latest version of RELIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ ENDIF()
 set(STBIN "OFF" CACHE STRING "")
 
 set(FP_METHD "INTEG;INTEG;INTEG;MONTY;LOWER;SLIDE" CACHE STRING "")
-set(COMP "-O3 -funroll-loops -fomit-frame-pointer" CACHE STRING "")
+set(CFLAGS "-O3 -funroll-loops -fomit-frame-pointer" CACHE STRING "")
 set(FP_PMERS "off" CACHE STRING "")
 set(FPX_METHD "INTEG;INTEG;LAZYR" CACHE STRING "")
 set(EP_PLAIN "off" CACHE STRING "")

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Features:
 * Batch verification
 * [Python bindings](https://github.com/Chia-Network/bls-signatures/tree/main/python-bindings)
 * [Pure python bls12-381 and signatures](https://github.com/Chia-Network/bls-signatures/tree/main/python-impl)
-* [JavaScript bindings](https://github.com/Chia-Network/bls-signatures/tree/main/js-bindings) (currently out of date - a great first issue!)
+* [JavaScript bindings](https://github.com/Chia-Network/bls-signatures/tree/main/js-bindings)
 
 ## Before you start
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,8 @@ set (CMAKE_CXX_STANDARD 17)
 # CMake 3.14+
 include(FetchContent)
 
-if (DEFINED ENV{RELIC_MASTER})
-  set(RELIC_GIT_TAG "origin/master")
+if (DEFINED ENV{RELIC_MAIN})
+  set(RELIC_GIT_TAG "origin/main")
 else ()
   set(RELIC_GIT_TAG "03a7c3b7fa43c0da6f3720e341f7d4f6a6d6f21e")
 endif ()

--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -236,6 +236,7 @@ void PrivateKey::AllocateKeyData()
 {
     assert(!keydata);
     keydata = Util::SecAlloc<bn_st>(1);
+    keydata->alloc = RLC_BN_SIZE;
     bn_zero(keydata);
 }
 

--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -236,7 +236,6 @@ void PrivateKey::AllocateKeyData()
 {
     assert(!keydata);
     keydata = Util::SecAlloc<bn_st>(1);
-    bn_init(keydata, RLC_BN_SIZE);
     bn_zero(keydata);
 }
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -21,7 +21,6 @@
 extern "C" {
 #include "relic.h"
 }
-#include "relic_test.h"
 #include "test-utils.hpp"
 using std::cout;
 using std::endl;


### PR DESCRIPTION
Minor fixes to take into account recent changes in RELIC:
* Rename `master` branch to `main`
* Remove unnecessary include of `relic_test.h`
* Replaced recently renamed `bn_init` with something simpler (assuming that `ALLOC == AUTO` remains in place)