### PR TITLE
Fix js typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ blsbench.*
 *.whl
 venv
 yarn-error.log
+
+.vs/
+out/

--- a/js-bindings/README.md
+++ b/js-bindings/README.md
@@ -1,7 +1,9 @@
-## Important Noice
+## Important Notice
+
 This is unofficial patch build for js-bindings of [bls-signatures](https://github.com/Chia-Network/bls-signatures).  
 Consider this branch as a temporary solution for current **[broken js build](https://github.com/Chia-Network/bls-signatures/issues/220)**
 until my PR will be merged to original repository. 
+
 ---
 
 ## bls-signatures

--- a/js-bindings/README.md
+++ b/js-bindings/README.md
@@ -1,3 +1,9 @@
+## Important Noice
+This is unofficial patch build for js-bindings of [bls-signatures](https://github.com/Chia-Network/bls-signatures).  
+Consider this branch as a temporary solution for current **[broken js build](https://github.com/Chia-Network/bls-signatures/issues/220)**
+until my PR will be merged to original repository. 
+---
+
 ## bls-signatures
 
 JavaScript library that implements BLS signatures with aggregation as in [Boneh, Drijvers, Neven 2018](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html), using the relic toolkit for cryptographic primitives (pairings, EC, hashing).
@@ -7,29 +13,154 @@ This library is a JavaScript port of the [Chia Network's BLS lib](https://github
 ### Usage
 
 ```bash
-npm i bls-signatures --save
+npm i Chia-Mine/bls-signatures#npm --save # or yarn add Chia-Mine/bls-signatures#npm
 ```
+
+### Creating keys and signatures
 ```javascript
-const blsSignatures = require('bls-signatures')();
-blsSignatures.then(() => {
-    // Instance is loaded and ready to be used
-    const { PrivateKey } = blsSignatures;
-    const privateKey = PrivateKey.fromSeed(Uint8Array.from([1,2,3]));
-    const sig = privateKey.sign(Uint8Array.from(Buffer.from("Hello world!")));
-    const isValidSignature = sig.verify();
-    
-    if (isValidSignature) {
-        // Do stuff...
-    }
-    
-    privateKey.delete();
-    sig.delete();
-})
+  const loadBls = require("bls-signatures");
+  const BLS = await loadBls();
+  
+  const seed = Uint8Array.from([
+    0,  50, 6,  244, 24,  199, 1,  25,  52,  88,  192,
+    19, 18, 12, 89,  6,   220, 18, 102, 58,  209, 82,
+    12, 62, 89, 110, 182, 9,   44, 20,  254, 22
+  ]);
+  
+  const sk = BLS.AugSchemeMPL.key_gen(seed);
+  const pk = sk.get_g1();
+  
+  const message = Uint8Array.from([1,2,3,4,5]);
+  const signature = BLS.AugSchemeMPL.sign(sk, message);
+  
+  let ok = BLS.AugSchemeMPL.verify(pk, message, signature);
+  console.log(ok); // true
+```
+
+### Serializing keys and signatures to bytes
+```javascript  
+  const skBytes = sk.serialize();
+  const pkBytes = pk.serialize();
+  const signatureBytes = signature.serialize();
+  
+  console.log(BLS.Util.hexStr(skBytes)); // true
+  console.log(BLS.Util.hexStr(pkBytes)); // true
+  console.log(BLS.Util.hexStr(signatureBytes)); // true
+  
+```
+
+### Loading keys and signatures from bytes
+```javascript
+  const skc = BLS.PrivateKey.fromBytes(skBytes, false);
+  const pk = BLS.G1Element.fromBytes(pkBytes);
+
+  const signature = BLS.G2Element.fromBytes(signatureBytes);
+```
+
+### Create aggregate signatures
+```javascript
+  // Generate some more private keys
+  seed[0] = 1;
+  const sk1 = BLS.AugSchemeMPL.key_gen(seed);
+  seed[0] = 2;
+  const sk2 = BLS.AugSchemeMPL.key_gen(seed);
+  const message2 = Uint8Array.from([1,2,3,4,5,6,7]);
+  
+  // Generate first sig
+  const pk1 = sk1.get_g1();
+  const sig1 = BLS.AugSchemeMPL.sign(sk1, message);
+  
+  // Generate second sig
+  const pk2 = sk2.get_g1();
+  const sig2 = BLS.AugSchemeMPL.sign(sk2, message2);
+  
+  // Signatures can be non-interactively combined by anyone
+  const aggSig = BLS.AugSchemeMPL.aggregate([sig1, sig2]);
+  
+  ok = BLS.AugSchemeMPL.aggregate_verify([pk1, pk2], [message, message2], aggSig);
+  console.log(ok); // true
+  
+```
+
+### Arbitrary trees of aggregates
+```javascript
+  seed[0] = 3;
+  const sk3 = BLS.AugSchemeMPL.key_gen(seed);
+  const pk3 = sk3.get_g1();
+  const message3 = Uint8Array.from([100, 2, 254, 88, 90, 45, 23]);
+  const sig3 = BLS.AugSchemeMPL.sign(sk3, message3);
+  
+  const aggSigFinal = BLS.AugSchemeMPL.aggregate([aggSig, sig3]);
+  ok = BLS.AugSchemeMPL.aggregate_verify([pk1, pk2, pk3], [message, message2, message3], aggSigFinal);
+  console.log(ok); // true
+```
+
+### Very fast verification with Proof of Possession scheme
+```javascript
+
+// If the same message is signed, you can use Proof of Posession (PopScheme) for efficiency
+  // A proof of possession MUST be passed around with the PK to ensure security.
+  const popSig1 = BLS.PopSchemeMPL.sign(sk1, message);
+  const popSig2 = BLS.PopSchemeMPL.sign(sk2, message);
+  const popSig3 = BLS.PopSchemeMPL.sign(sk3, message);
+  const pop1 = BLS.PopSchemeMPL.pop_prove(sk1);
+  const pop2 = BLS.PopSchemeMPL.pop_prove(sk2);
+  const pop3 = BLS.PopSchemeMPL.pop_prove(sk3);
+  
+  ok = BLS.PopSchemeMPL.pop_verify(pk1, pop1);
+  console.log(ok); // true
+  ok = BLS.PopSchemeMPL.pop_verify(pk2, pop2);
+  console.log(ok); // true
+  ok = BLS.PopSchemeMPL.pop_verify(pk3, pop3);
+  console.log(ok); // true
+  
+  const popSigAgg = BLS.PopSchemeMPL.aggregate([popSig1, popSig2, popSig3]);
+  ok = BLS.PopSchemeMPL.fast_aggregate_verify([pk1, pk2, pk3], message, popSigAgg);
+  console.log(ok); // true
+  
+  // Aggregate public key, indistinguishable from a single public key
+  const popAggPk = pk1.add(pk2).add(pk3);
+  ok = BLS.PopSchemeMPL.verify(popAggPk, message, popSigAgg);
+  console.log(ok); // true
+  
+  // Aggregate private keys
+  const aggSk = BLS.PrivateKey.aggregate([sk1, sk2, sk3]);
+  ok = (BLS.PopSchemeMPL.sign(aggSk, message).equalTo(popSigAgg));
+  console.log(ok); // true
+```
+
+### HD keys using [EIP-2333](https://github.com/ethereum/EIPs/pull/2333)
+```javascript
+  // You can derive 'child' keys from any key, to create arbitrary trees. 4 byte indeces are used.
+  // Hardened (more secure, but no parent pk -> child pk)
+  const masterSk = BLS.AugSchemeMPL.key_gen(seed);
+  const child = BLS.AugSchemeMPL.derive_child_sk(masterSk, 152);
+  const grandChild = BLS.AugSchemeMPL.derive_child_sk(child, 952);
+  
+  // Unhardened (less secure, but can go from parent pk -> child pk), BIP32 style
+  const masterPk = masterSk.get_g1();
+  const childU = BLS.AugSchemeMPL.derive_child_sk_unhardened(masterSk, 22);
+  const grandchildU = BLS.AugSchemeMPL.derive_child_sk_unhardened(childU, 0);
+  
+  const childUPk = BLS.AugSchemeMPL.derive_child_pk_unhardened(masterPk, 22);
+  const grandchildUPk = BLS.AugSchemeMPL.derive_child_pk_unhardened(childUPk, 0);
+  
+  ok = (grandchildUPk.equalTo(grandchildU.get_g1()));
+  console.log(ok); // true
 ```
 
 Please refer to the library's [typings](./blsjs.d.ts) for detailed API information. Use cases can be found in the [original lib's readme](../README.md).
 
-__Important note on usage:__ Since this library is a WebAssembly port of the c++ library, JavaScript's automatic memory management isn't available. Please, delete all objects manually if they are not needed anymore by calling the delete method on them, as shown in the example above.
+__Important note on usage:__ Since this library is a WebAssembly port of the c++ library, JavaScript's automatic memory management isn't available. Please, delete all objects manually if they are not needed anymore by calling the delete method on them, as shown in the example below.
+
+```javascript
+  sk.delete();
+  // ...
+  pk.delete();
+  // ...
+  sig1.delete();
+  // ...
+```
 
 ### Build
 

--- a/js-bindings/README.md
+++ b/js-bindings/README.md
@@ -37,18 +37,18 @@ npm i bls-signatures --save # or yarn add bls-signatures
   const pkBytes = pk.serialize();
   const signatureBytes = signature.serialize();
   
-  console.log(BLS.Util.hexStr(skBytes)); // true
-  console.log(BLS.Util.hexStr(pkBytes)); // true
-  console.log(BLS.Util.hexStr(signatureBytes)); // true
+  console.log(BLS.Util.hex_str(skBytes)); // true
+  console.log(BLS.Util.hex_str(pkBytes)); // true
+  console.log(BLS.Util.hex_str(signatureBytes)); // true
   
 ```
 
 ### Loading keys and signatures from bytes
 ```javascript
-  const skc = BLS.PrivateKey.fromBytes(skBytes, false);
-  const pk = BLS.G1Element.fromBytes(pkBytes);
+  const skc = BLS.PrivateKey.from_bytes(skBytes, false);
+  const pk = BLS.G1Element.from_bytes(pkBytes);
 
-  const signature = BLS.G2Element.fromBytes(signatureBytes);
+  const signature = BLS.G2Element.from_bytes(signatureBytes);
 ```
 
 ### Create aggregate signatures
@@ -92,7 +92,7 @@ npm i bls-signatures --save # or yarn add bls-signatures
 ### Very fast verification with Proof of Possession scheme
 ```javascript
 
-// If the same message is signed, you can use Proof of Posession (PopScheme) for efficiency
+  // If the same message is signed, you can use Proof of Posession (PopScheme) for efficiency
   // A proof of possession MUST be passed around with the PK to ensure security.
   const popSig1 = BLS.PopSchemeMPL.sign(sk1, message);
   const popSig2 = BLS.PopSchemeMPL.sign(sk2, message);
@@ -119,7 +119,7 @@ npm i bls-signatures --save # or yarn add bls-signatures
   
   // Aggregate private keys
   const aggSk = BLS.PrivateKey.aggregate([sk1, sk2, sk3]);
-  ok = (BLS.PopSchemeMPL.sign(aggSk, message).equalTo(popSigAgg));
+  ok = (BLS.PopSchemeMPL.sign(aggSk, message).equal_to(popSigAgg));
   console.log(ok); // true
 ```
 

--- a/js-bindings/README.md
+++ b/js-bindings/README.md
@@ -12,20 +12,20 @@ npm i bls-signatures --save # or yarn add bls-signatures
 
 ### Creating keys and signatures
 ```javascript
-  const loadBls = require("bls-signatures");
-  const BLS = await loadBls();
+  var loadBls = require("bls-signatures");
+  var BLS = await loadBls();
   
-  const seed = Uint8Array.from([
+  var seed = Uint8Array.from([
     0,  50, 6,  244, 24,  199, 1,  25,  52,  88,  192,
     19, 18, 12, 89,  6,   220, 18, 102, 58,  209, 82,
     12, 62, 89, 110, 182, 9,   44, 20,  254, 22
   ]);
   
-  const sk = BLS.AugSchemeMPL.key_gen(seed);
-  const pk = sk.get_g1();
+  var sk = BLS.AugSchemeMPL.key_gen(seed);
+  var pk = sk.get_g1();
   
-  const message = Uint8Array.from([1,2,3,4,5]);
-  const signature = BLS.AugSchemeMPL.sign(sk, message);
+  var message = Uint8Array.from([1,2,3,4,5]);
+  var signature = BLS.AugSchemeMPL.sign(sk, message);
   
   let ok = BLS.AugSchemeMPL.verify(pk, message, signature);
   console.log(ok); // true
@@ -33,9 +33,9 @@ npm i bls-signatures --save # or yarn add bls-signatures
 
 ### Serializing keys and signatures to bytes
 ```javascript  
-  const skBytes = sk.serialize();
-  const pkBytes = pk.serialize();
-  const signatureBytes = signature.serialize();
+  var skBytes = sk.serialize();
+  var pkBytes = pk.serialize();
+  var signatureBytes = signature.serialize();
   
   console.log(BLS.Util.hex_str(skBytes));
   console.log(BLS.Util.hex_str(pkBytes));
@@ -45,31 +45,31 @@ npm i bls-signatures --save # or yarn add bls-signatures
 
 ### Loading keys and signatures from bytes
 ```javascript
-  const skc = BLS.PrivateKey.from_bytes(skBytes, false);
-  const pk = BLS.G1Element.from_bytes(pkBytes);
+  var skc = BLS.PrivateKey.from_bytes(skBytes, false);
+  var pk = BLS.G1Element.from_bytes(pkBytes);
 
-  const signature = BLS.G2Element.from_bytes(signatureBytes);
+  var signature = BLS.G2Element.from_bytes(signatureBytes);
 ```
 
 ### Create aggregate signatures
 ```javascript
   // Generate some more private keys
   seed[0] = 1;
-  const sk1 = BLS.AugSchemeMPL.key_gen(seed);
+  var sk1 = BLS.AugSchemeMPL.key_gen(seed);
   seed[0] = 2;
-  const sk2 = BLS.AugSchemeMPL.key_gen(seed);
-  const message2 = Uint8Array.from([1,2,3,4,5,6,7]);
+  var sk2 = BLS.AugSchemeMPL.key_gen(seed);
+  var message2 = Uint8Array.from([1,2,3,4,5,6,7]);
   
   // Generate first sig
-  const pk1 = sk1.get_g1();
-  const sig1 = BLS.AugSchemeMPL.sign(sk1, message);
+  var pk1 = sk1.get_g1();
+  var sig1 = BLS.AugSchemeMPL.sign(sk1, message);
   
   // Generate second sig
-  const pk2 = sk2.get_g1();
-  const sig2 = BLS.AugSchemeMPL.sign(sk2, message2);
+  var pk2 = sk2.get_g1();
+  var sig2 = BLS.AugSchemeMPL.sign(sk2, message2);
   
   // Signatures can be non-interactively combined by anyone
-  const aggSig = BLS.AugSchemeMPL.aggregate([sig1, sig2]);
+  var aggSig = BLS.AugSchemeMPL.aggregate([sig1, sig2]);
   
   ok = BLS.AugSchemeMPL.aggregate_verify([pk1, pk2], [message, message2], aggSig);
   console.log(ok); // true
@@ -79,12 +79,12 @@ npm i bls-signatures --save # or yarn add bls-signatures
 ### Arbitrary trees of aggregates
 ```javascript
   seed[0] = 3;
-  const sk3 = BLS.AugSchemeMPL.key_gen(seed);
-  const pk3 = sk3.get_g1();
-  const message3 = Uint8Array.from([100, 2, 254, 88, 90, 45, 23]);
-  const sig3 = BLS.AugSchemeMPL.sign(sk3, message3);
+  var sk3 = BLS.AugSchemeMPL.key_gen(seed);
+  var pk3 = sk3.get_g1();
+  var message3 = Uint8Array.from([100, 2, 254, 88, 90, 45, 23]);
+  var sig3 = BLS.AugSchemeMPL.sign(sk3, message3);
   
-  const aggSigFinal = BLS.AugSchemeMPL.aggregate([aggSig, sig3]);
+  var aggSigFinal = BLS.AugSchemeMPL.aggregate([aggSig, sig3]);
   ok = BLS.AugSchemeMPL.aggregate_verify([pk1, pk2, pk3], [message, message2, message3], aggSigFinal);
   console.log(ok); // true
 ```
@@ -94,12 +94,12 @@ npm i bls-signatures --save # or yarn add bls-signatures
 
   // If the same message is signed, you can use Proof of Posession (PopScheme) for efficiency
   // A proof of possession MUST be passed around with the PK to ensure security.
-  const popSig1 = BLS.PopSchemeMPL.sign(sk1, message);
-  const popSig2 = BLS.PopSchemeMPL.sign(sk2, message);
-  const popSig3 = BLS.PopSchemeMPL.sign(sk3, message);
-  const pop1 = BLS.PopSchemeMPL.pop_prove(sk1);
-  const pop2 = BLS.PopSchemeMPL.pop_prove(sk2);
-  const pop3 = BLS.PopSchemeMPL.pop_prove(sk3);
+  var popSig1 = BLS.PopSchemeMPL.sign(sk1, message);
+  var popSig2 = BLS.PopSchemeMPL.sign(sk2, message);
+  var popSig3 = BLS.PopSchemeMPL.sign(sk3, message);
+  var pop1 = BLS.PopSchemeMPL.pop_prove(sk1);
+  var pop2 = BLS.PopSchemeMPL.pop_prove(sk2);
+  var pop3 = BLS.PopSchemeMPL.pop_prove(sk3);
   
   ok = BLS.PopSchemeMPL.pop_verify(pk1, pop1);
   console.log(ok); // true
@@ -108,17 +108,17 @@ npm i bls-signatures --save # or yarn add bls-signatures
   ok = BLS.PopSchemeMPL.pop_verify(pk3, pop3);
   console.log(ok); // true
   
-  const popSigAgg = BLS.PopSchemeMPL.aggregate([popSig1, popSig2, popSig3]);
+  var popSigAgg = BLS.PopSchemeMPL.aggregate([popSig1, popSig2, popSig3]);
   ok = BLS.PopSchemeMPL.fast_aggregate_verify([pk1, pk2, pk3], message, popSigAgg);
   console.log(ok); // true
   
   // Aggregate public key, indistinguishable from a single public key
-  const popAggPk = pk1.add(pk2).add(pk3);
+  var popAggPk = pk1.add(pk2).add(pk3);
   ok = BLS.PopSchemeMPL.verify(popAggPk, message, popSigAgg);
   console.log(ok); // true
   
   // Aggregate private keys
-  const aggSk = BLS.PrivateKey.aggregate([sk1, sk2, sk3]);
+  var aggSk = BLS.PrivateKey.aggregate([sk1, sk2, sk3]);
   ok = (BLS.PopSchemeMPL.sign(aggSk, message).equal_to(popSigAgg));
   console.log(ok); // true
 ```
@@ -127,17 +127,17 @@ npm i bls-signatures --save # or yarn add bls-signatures
 ```javascript
   // You can derive 'child' keys from any key, to create arbitrary trees. 4 byte indeces are used.
   // Hardened (more secure, but no parent pk -> child pk)
-  const masterSk = BLS.AugSchemeMPL.key_gen(seed);
-  const child = BLS.AugSchemeMPL.derive_child_sk(masterSk, 152);
-  const grandChild = BLS.AugSchemeMPL.derive_child_sk(child, 952);
+  var masterSk = BLS.AugSchemeMPL.key_gen(seed);
+  var child = BLS.AugSchemeMPL.derive_child_sk(masterSk, 152);
+  var grandChild = BLS.AugSchemeMPL.derive_child_sk(child, 952);
   
   // Unhardened (less secure, but can go from parent pk -> child pk), BIP32 style
-  const masterPk = masterSk.get_g1();
-  const childU = BLS.AugSchemeMPL.derive_child_sk_unhardened(masterSk, 22);
-  const grandchildU = BLS.AugSchemeMPL.derive_child_sk_unhardened(childU, 0);
+  var masterPk = masterSk.get_g1();
+  var childU = BLS.AugSchemeMPL.derive_child_sk_unhardened(masterSk, 22);
+  var grandchildU = BLS.AugSchemeMPL.derive_child_sk_unhardened(childU, 0);
   
-  const childUPk = BLS.AugSchemeMPL.derive_child_pk_unhardened(masterPk, 22);
-  const grandchildUPk = BLS.AugSchemeMPL.derive_child_pk_unhardened(childUPk, 0);
+  var childUPk = BLS.AugSchemeMPL.derive_child_pk_unhardened(masterPk, 22);
+  var grandchildUPk = BLS.AugSchemeMPL.derive_child_pk_unhardened(childUPk, 0);
   
   ok = (grandchildUPk.equal_to(grandchildU.get_g1()));
   console.log(ok); // true

--- a/js-bindings/README.md
+++ b/js-bindings/README.md
@@ -139,7 +139,7 @@ npm i bls-signatures --save # or yarn add bls-signatures
   const childUPk = BLS.AugSchemeMPL.derive_child_pk_unhardened(masterPk, 22);
   const grandchildUPk = BLS.AugSchemeMPL.derive_child_pk_unhardened(childUPk, 0);
   
-  ok = (grandchildUPk.equalTo(grandchildU.get_g1()));
+  ok = (grandchildUPk.equal_to(grandchildU.get_g1()));
   console.log(ok); // true
 ```
 

--- a/js-bindings/README.md
+++ b/js-bindings/README.md
@@ -37,9 +37,9 @@ npm i bls-signatures --save # or yarn add bls-signatures
   const pkBytes = pk.serialize();
   const signatureBytes = signature.serialize();
   
-  console.log(BLS.Util.hex_str(skBytes)); // true
-  console.log(BLS.Util.hex_str(pkBytes)); // true
-  console.log(BLS.Util.hex_str(signatureBytes)); // true
+  console.log(BLS.Util.hex_str(skBytes));
+  console.log(BLS.Util.hex_str(pkBytes));
+  console.log(BLS.Util.hex_str(signatureBytes));
   
 ```
 

--- a/js-bindings/README.md
+++ b/js-bindings/README.md
@@ -1,11 +1,3 @@
-## Important Notice
-
-This is unofficial patch build for js-bindings of [bls-signatures](https://github.com/Chia-Network/bls-signatures).  
-Consider this branch as a temporary solution for current **[broken js build](https://github.com/Chia-Network/bls-signatures/issues/220)**
-until my PR will be merged to original repository. 
-
----
-
 ## bls-signatures
 
 JavaScript library that implements BLS signatures with aggregation as in [Boneh, Drijvers, Neven 2018](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html), using the relic toolkit for cryptographic primitives (pairings, EC, hashing).
@@ -15,7 +7,7 @@ This library is a JavaScript port of the [Chia Network's BLS lib](https://github
 ### Usage
 
 ```bash
-npm i Chia-Mine/bls-signatures#npm --save # or yarn add Chia-Mine/bls-signatures#npm
+npm i bls-signatures --save # or yarn add bls-signatures
 ```
 
 ### Creating keys and signatures

--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -1,4 +1,4 @@
-declare class AugSchemeMPL {
+export declare class AugSchemeMPL {
   static sk_to_g1(sk: PrivateKey): G1Element;
   static key_gen(msg: Uint8Array): PrivateKey;
   static sign(sk: PrivateKey, msg: Uint8Array): G2Element;
@@ -11,7 +11,7 @@ declare class AugSchemeMPL {
   static derive_child_pk_unhardened(pk: G1Element, index: number): G1Element;
 }
 
-declare class BasicSchemeMPL {
+export declare class BasicSchemeMPL {
   static sk_to_g1(sk: PrivateKey): G1Element;
   static key_gen(msg: Uint8Array): PrivateKey;
   static sign(sk: PrivateKey, msg: Uint8Array): G2Element;
@@ -23,7 +23,7 @@ declare class BasicSchemeMPL {
   static derive_child_pk_unhardened(pk: G1Element, index: number): G1Element;
 }
 
-declare class PopSchemeMPL {
+export declare class PopSchemeMPL {
   static sk_to_g1(sk: PrivateKey): G1Element;
   static key_gen(msg: Uint8Array): PrivateKey;
   static sign(sk: PrivateKey, msg: Uint8Array): G2Element;
@@ -38,7 +38,7 @@ declare class PopSchemeMPL {
   static fast_aggregate_verify(pks: G1Element[], msg: Uint8Array, sig: G2Element): boolean;
 }
 
-declare class G1Element {
+export declare class G1Element {
   static SIZE: number;
   static from_bytes(bytes: Uint8Array): G1Element;
   static generator(): G2Element;
@@ -52,7 +52,7 @@ declare class G1Element {
   delete(): void;
 }
 
-declare class G2Element {
+export declare class G2Element {
   static SIZE: number;
   static from_bytes(bytes: Uint8Array): G2Element;
   static from_g2(sk: G2Element): G2Element;
@@ -67,7 +67,7 @@ declare class G2Element {
   delete(): void;
 }
 
-declare class PrivateKey {
+export declare class PrivateKey {
   static PRIVATE_KEY_SIZE: number;
   static from_bytes(bytes: Uint8Array, modOrder: boolean): PrivateKey;
   static aggregate(pks: PrivateKey[]): PrivateKey;
@@ -81,13 +81,13 @@ declare class PrivateKey {
   delete(): void;
 }
 
-declare class Bignum {
+export declare class Bignum {
   static from_string(s: string, radix: number): Bignum;
   toString(radix: number): string;
   delete(): void;
 }
 
-declare class Util {
+export declare class Util {
   static hash256(msg: Uint8Array): Uint8Array;
   static hex_str(msg: Uint8Array): string;
 }
@@ -105,4 +105,4 @@ interface ModuleInstance {
 
 declare function createModule(options?: {}): Promise<ModuleInstance>;
 
-export = createModule;
+export default createModule;

--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -40,7 +40,7 @@ declare class PopSchemeMPL {
 
 declare class G1Element {
   static SIZE: number;
-  static fromBytes(bytes: Uint8Array): G1Element;
+  static from_bytes(bytes: Uint8Array): G1Element;
   static generator(): G2Element;
   serialize(): Uint8Array;
   negate(): G1Element;
@@ -48,28 +48,28 @@ declare class G1Element {
   get_fingerprint(): number;
   add(el: G1Element): G1Element;
   mul(bn: Bignum): G1Element;
-  equalTo(el: G1Element): boolean;
+  equal_to(el: G1Element): boolean;
   delete(): void;
 }
 
 declare class G2Element {
   static SIZE: number;
-  static fromBytes(bytes: Uint8Array): G2Element;
-  static fromG2Element(sk: G2Element): G2Element;
-  static aggregateSigs(sigs: G2Element[]): G2Element;
+  static from_bytes(bytes: Uint8Array): G2Element;
+  static from_g2(sk: G2Element): G2Element;
+  static aggregate_sigs(sigs: G2Element[]): G2Element;
   static generator(): G2Element;
   serialize(): Uint8Array;
   negate(): G2Element;
   deepcopy(): G2Element;
   add(el: G2Element): G2Element;
   mul(bn: Bignum): G2Element;
-  equalTo(el: G2Element): boolean;
+  equal_to(el: G2Element): boolean;
   delete(): void;
 }
 
 declare class PrivateKey {
   static PRIVATE_KEY_SIZE: number;
-  static fromBytes(bytes: Uint8Array, modOrder: boolean): PrivateKey;
+  static from_bytes(bytes: Uint8Array, modOrder: boolean): PrivateKey;
   static aggregate(pks: PrivateKey[]): PrivateKey;
   deepcopy(): PrivateKey;
   serialize(): Uint8Array;
@@ -77,19 +77,19 @@ declare class PrivateKey {
   get_g2(): G2Element;
   mul_g1(el: G1Element): G1Element;
   mul_g2(el: G2Element): G2Element;
-  equalTo(key: PrivateKey): boolean;
+  equal_to(key: PrivateKey): boolean;
   delete(): void;
 }
 
 declare class Bignum {
-  static fromString(s: string, radix: number): Bignum;
+  static from_string(s: string, radix: number): Bignum;
   toString(radix: number): string;
   delete(): void;
 }
 
 declare class Util {
   static hash256(msg: Uint8Array): Uint8Array;
-  static hexStr(msg: Uint8Array): string;
+  static hex_str(msg: Uint8Array): string;
 }
 
 interface ModuleInstance {

--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -48,6 +48,7 @@ declare class G1Element {
   get_fingerprint(): number;
   add(): G1Element;
   mul(): G1Element;
+  delete(): void;
 }
 
 declare class G2Element {
@@ -57,20 +58,23 @@ declare class G2Element {
   serialize(): Uint8Array;
   negate(): G2Element;
   deepcopy(): G2Element;
+  delete(): void;
 }
 
 declare class PrivateKey {
-    static PRIVATE_KEY_SIZE: number;
-    static fromBytes(bytes: Uint8Array, modOrder: boolean): PrivateKey;
-    static aggregate(pks: PrivateKey[]): PrivateKey;
-    deepcopy(): PrivateKey;
-    serialize(): Uint8Array;
-    get_g1(): G1Element;
+  static PRIVATE_KEY_SIZE: number;
+  static fromBytes(bytes: Uint8Array, modOrder: boolean): PrivateKey;
+  static aggregate(pks: PrivateKey[]): PrivateKey;
+  deepcopy(): PrivateKey;
+  serialize(): Uint8Array;
+  get_g1(): G1Element;
+  delete(): void;
 }
 
 declare class Bignum {
   static fromString(s: string, radix: number): Bignum;
   toString(radix: number): string;
+  delete(): void;
 }
 
 declare class Util {

--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -40,8 +40,8 @@ declare class PopSchemeMPL {
 
 declare class G1Element {
   static SIZE: number;
-  fromBytes(msg: Uint8Array): G1Element;
-  generator(): G2Element;
+  static fromBytes(msg: Uint8Array): G1Element;
+  static generator(): G2Element;
   serialize(): Uint8Array;
   negate(): G1Element;
   deepcopy(): G1Element;
@@ -53,8 +53,8 @@ declare class G1Element {
 
 declare class G2Element {
   static SIZE: number;
-  fromBytes(): G2Element;
-  generator(): G2Element;
+  static fromBytes(): G2Element;
+  static generator(): G2Element;
   serialize(): Uint8Array;
   negate(): G2Element;
   deepcopy(): G2Element;

--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -92,7 +92,7 @@ export declare class Util {
   static hex_str(msg: Uint8Array): string;
 }
 
-interface ModuleInstance {
+export interface ModuleInstance {
   AugSchemeMPL: typeof AugSchemeMPL;
   BasicSchemeMPL: typeof BasicSchemeMPL;
   PopSchemeMPL: typeof PopSchemeMPL;

--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -75,6 +75,7 @@ declare class Bignum {
 
 declare class Util {
   static hash256(msg: Uint8Array): Uint8Array;
+  static hexStr(msg: Uint8Array): string;
 }
 
 interface ModuleInstance {

--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -1,187 +1,93 @@
+declare class AugSchemeMPL {
+  static sk_to_g1(sk: PrivateKey): G1Element;
+  static key_gen(msg: Uint8Array): PrivateKey;
+  static sign(sk: PrivateKey, msg: Uint8Array): G2Element;
+  static sign_prepend(sk: PrivateKey, msg: Uint8Array, prependPk: G1Element): G2Element;
+  static verify(pk: G1Element, msg: Uint8Array, sig: G2Element): boolean;
+  static aggregate(g2Elements: G2Element[]): G2Element;
+  static aggregate_verify(pks: G1Element[], msgs: Uint8Array[], sig: G2Element): boolean;
+  static derive_child_sk(sk: PrivateKey, index: number): PrivateKey;
+  static derive_child_sk_unhardened(sk: PrivateKey, index: number): PrivateKey;
+  static derive_child_pk_unhardened(pk: G1Element, index: number): G1Element;
+}
+
+declare class BasicSchemeMPL {
+  static sk_to_g1(sk: PrivateKey): G1Element;
+  static key_gen(msg: Uint8Array): PrivateKey;
+  static sign(sk: PrivateKey, msg: Uint8Array): G2Element;
+  static verify(pk: G1Element, msg: Uint8Array, sig: G2Element): boolean;
+  static aggregate(g2Elements: G2Element[]): G2Element;
+  static aggregate_verify(pks: G1Element[], msgs: Uint8Array[], sig: G2Element): boolean;
+  static derive_child_sk(sk: PrivateKey, index: number): PrivateKey;
+  static derive_child_sk_unhardened(sk: PrivateKey, index: number): PrivateKey;
+  static derive_child_pk_unhardened(pk: G1Element, index: number): G1Element;
+}
+
+declare class PopSchemeMPL {
+  static sk_to_g1(sk: PrivateKey): G1Element;
+  static key_gen(msg: Uint8Array): PrivateKey;
+  static sign(sk: PrivateKey, msg: Uint8Array): G2Element;
+  static verify(pk: G1Element, msg: Uint8Array, sig: G2Element): boolean;
+  static aggregate(g2Elements: G2Element[]): G2Element;
+  static aggregate_verify(pks: G1Element[], msgs: Uint8Array[], sig: G2Element): boolean;
+  static derive_child_sk(sk: PrivateKey, index: number): PrivateKey;
+  static derive_child_sk_unhardened(sk: PrivateKey, index: number): PrivateKey;
+  static derive_child_pk_unhardened(pk: G1Element, index: number): G1Element;
+  static pop_prove(sk: PrivateKey): G2Element;
+  static pop_verify(pk: G1Element, signatureProof: G2Element): boolean;
+  static fast_aggregate_verify(pks: G1Element[], msg: Uint8Array, sig: G2Element): boolean;
+}
+
+declare class G1Element {
+  static SIZE: number;
+  fromBytes(msg: Uint8Array): G1Element;
+  generator(): G2Element;
+  serialize(): Uint8Array;
+  negate(): G1Element;
+  deepcopy(): G1Element;
+  get_fingerprint(): number;
+  add(): G1Element;
+  mul(): G1Element;
+}
+
+declare class G2Element {
+  static SIZE: number;
+  fromBytes(): G2Element;
+  generator(): G2Element;
+  serialize(): Uint8Array;
+  negate(): G2Element;
+  deepcopy(): G2Element;
+}
+
 declare class PrivateKey {
     static PRIVATE_KEY_SIZE: number;
-
-    static fromSeed(seed: Uint8Array): PrivateKey;
-
     static fromBytes(bytes: Uint8Array, modOrder: boolean): PrivateKey;
-
-    static aggregate(privateKeys: PrivateKey[], publicKeys: PublicKey[]): PrivateKey;
-
-    static aggregateInsecure(privateKeys: PrivateKey[]): PrivateKey;
-
-    getPublicKey(): PublicKey;
-
+    static aggregate(pks: PrivateKey[]): PrivateKey;
+    deepcopy(): PrivateKey;
     serialize(): Uint8Array;
-
-    sign(message: Uint8Array): Signature;
-
-    signInsecure(message: Uint8Array): InsecureSignature;
-
-    signPrehashed(messageHash: Uint8Array): Signature;
-
-    delete(): void;
+    get_g1(): G1Element;
 }
 
-declare class InsecureSignature {
-    static SIGNATURE_SIZE: number;
-
-    static fromBytes(bytes: Uint8Array);
-
-    static aggregate(signatures: InsecureSignature[]): InsecureSignature;
-
-    verify(hashes: Uint8Array[], pubKeys: PublicKey[]): boolean;
-
-    divideBy(insecureSignatures: InsecureSignature[]): InsecureSignature;
-
-    serialize(): Uint8Array;
-
-    delete(): void;
+declare class Bignum {
+  static fromString(s: string, radix: number): Bignum;
+  toString(radix: number): string;
 }
 
-declare class Signature {
-    static SIGNATURE_SIZE: number;
-
-    static fromBytes(bytes: Uint8Array): Signature;
-
-    static fromBytesAndAggregationInfo(bytes: Uint8Array, aggregationInfo: AggregationInfo): Signature;
-
-    static aggregateSigs(signatures: Signature[]): Signature;
-
-    serialize(): Uint8Array;
-
-    verify(): boolean;
-
-    getAggregationInfo(): AggregationInfo;
-
-    setAggregationInfo(aggregationInfo: AggregationInfo): void;
-
-    delete(): void;
-}
-
-declare class PublicKey {
-    static PUBLIC_KEY_SIZE: number;
-
-    static fromBytes(bytes: Uint8Array): PublicKey;
-
-    static aggregate(publicKeys: PublicKey[]): PublicKey;
-
-    static aggregateInsecure(publicKeys: PublicKey[]): PublicKey;
-
-    getFingerprint(): number;
-
-    serialize(): Uint8Array;
-
-    delete(): void;
-}
-
-declare class AggregationInfo {
-    static fromMsgHash(publicKey: PublicKey, messageHash: Uint8Array): AggregationInfo;
-
-    static fromMsg(publicKey: PublicKey, message: Uint8Array): AggregationInfo;
-
-    static fromBuffers(pubKeys: PublicKey[], msgHashes: Uint8Array[], exponents: Uint8Array[]): AggregationInfo;
-
-    getPublicKeys(): PublicKey[];
-
-    getMessageHashes(): Uint8Array[];
-
-    getExponents(): Uint8Array[];
-
-    delete(): void;
-}
-
-declare class ExtendedPrivateKey {
-    static EXTENDED_PRIVATE_KEY_SIZE: number;
-
-    static fromSeed(seed: Uint8Array): ExtendedPrivateKey;
-
-    static fromBytes(bytes: Uint8Array): ExtendedPrivateKey;
-
-    privateChild(index: number): ExtendedPrivateKey;
-
-    publicChild(index: number): ExtendedPublicKey;
-
-    getVersion(): number;
-
-    getDepth(): number;
-
-    getParentFingerprint(): number;
-
-    getChildNumber(): number;
-
-    getChainCode(): ChainCode;
-
-    getPrivateKey(): PrivateKey;
-
-    getPublicKey(): PublicKey;
-
-    getExtendedPublicKey(): ExtendedPublicKey;
-
-    serialize(): Uint8Array;
-
-    delete(): void;
-}
-
-declare class ExtendedPublicKey {
-    static VERSION: number;
-    static EXTENDED_PUBLIC_KEY_SIZE: number;
-
-    static fromBytes(bytes: Uint8Array): ExtendedPublicKey;
-
-    publicChild(index: number): ExtendedPublicKey;
-
-    getVersion(): number;
-
-    getDepth(): number;
-
-    getParentFingerprint(): number;
-
-    getChildNumber(): number;
-
-    getPublicKey(): PublicKey;
-
-    getChainCode(): ChainCode;
-
-    serialize(): Uint8Array;
-
-    delete(): void;
-}
-
-declare class ChainCode {
-    static CHAIN_CODE_SIZE: number;
-
-    static fromBytes(bytes: Uint8Array);
-
-    serialize(): Uint8Array;
-
-    delete(): void;
-}
-
-declare class Threshold {
-    static create(commitment: PublicKey[], secretFragments: PrivateKey[], threshold: number, playersCount: number): PrivateKey;
-
-    static signWithCoefficient(sk: PrivateKey, message: Uint8Array, playerIndex: number, players: number[]): InsecureSignature;
-
-    static aggregateUnitSigs(signatures: InsecureSignature[], message: Uint8Array, players: number[]): InsecureSignature;
-
-    static verifySecretFragment(playerIndex: number, secretFragment: PrivateKey, commitment: PublicKey[], threshold: number): boolean;
+declare class Util {
+  static hash256(msg: Uint8Array): Uint8Array;
 }
 
 interface ModuleInstance {
-    then: (callback: (moduleInstance: ModuleInstance) => any) => ModuleInstance;
-    PrivateKey: typeof PrivateKey;
-    InsecureSignature: typeof InsecureSignature;
-    Signature: typeof Signature;
-    PublicKey: typeof PublicKey;
-    AggregationInfo: typeof AggregationInfo;
-    ExtendedPrivateKey: typeof ExtendedPrivateKey;
-    ExtendedPublicKey: typeof ExtendedPublicKey;
-    ChainCode: typeof ChainCode;
-    Threshold: typeof Threshold;
-    DHKeyExchange(privateKey: PrivateKey, publicKey: PublicKey);
-    GROUP_ORDER: string;
+  AugSchemeMPL: typeof AugSchemeMPL;
+  BasicSchemeMPL: typeof BasicSchemeMPL;
+  PopSchemeMPL: typeof PopSchemeMPL;
+  G1Element: typeof G1Element;
+  G2Element: typeof G2Element;
+  PrivateKey: typeof PrivateKey;
+  Bignum: typeof Bignum;
+  Util: typeof Util;
 }
 
-declare function createModule(options?: {}): ModuleInstance;
+declare function createModule(options?: {}): Promise<ModuleInstance>;
 
 export = createModule;

--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -40,7 +40,7 @@ declare class PopSchemeMPL {
 
 declare class G1Element {
   static SIZE: number;
-  static fromBytes(msg: Uint8Array): G1Element;
+  static fromBytes(bytes: Uint8Array): G1Element;
   static generator(): G2Element;
   serialize(): Uint8Array;
   negate(): G1Element;
@@ -48,16 +48,22 @@ declare class G1Element {
   get_fingerprint(): number;
   add(): G1Element;
   mul(): G1Element;
+  equalTo(pk: G1Element): boolean;
   delete(): void;
 }
 
 declare class G2Element {
   static SIZE: number;
-  static fromBytes(): G2Element;
+  static fromBytes(bytes: Uint8Array): G2Element;
+  static fromG2Element(sk: G2Element): G2Element;
+  static aggregateSigs(sigs: G2Element[]): G2Element;
   static generator(): G2Element;
   serialize(): Uint8Array;
   negate(): G2Element;
   deepcopy(): G2Element;
+  add(): G2Element;
+  mul(): G2Element;
+  equalTo(sk: G2Element): boolean;
   delete(): void;
 }
 
@@ -68,6 +74,10 @@ declare class PrivateKey {
   deepcopy(): PrivateKey;
   serialize(): Uint8Array;
   get_g1(): G1Element;
+  get_g2(): G2Element;
+  mul_g1(): G1Element;
+  mul_g2(): G2Element;
+  equalTo(key: PrivateKey): boolean;
   delete(): void;
 }
 

--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -46,9 +46,9 @@ declare class G1Element {
   negate(): G1Element;
   deepcopy(): G1Element;
   get_fingerprint(): number;
-  add(): G1Element;
-  mul(): G1Element;
-  equalTo(pk: G1Element): boolean;
+  add(el: G1Element): G1Element;
+  mul(bn: Bignum): G1Element;
+  equalTo(el: G1Element): boolean;
   delete(): void;
 }
 
@@ -61,9 +61,9 @@ declare class G2Element {
   serialize(): Uint8Array;
   negate(): G2Element;
   deepcopy(): G2Element;
-  add(): G2Element;
-  mul(): G2Element;
-  equalTo(sk: G2Element): boolean;
+  add(el: G2Element): G2Element;
+  mul(bn: Bignum): G2Element;
+  equalTo(el: G2Element): boolean;
   delete(): void;
 }
 
@@ -75,8 +75,8 @@ declare class PrivateKey {
   serialize(): Uint8Array;
   get_g1(): G1Element;
   get_g2(): G2Element;
-  mul_g1(): G1Element;
-  mul_g2(): G2Element;
+  mul_g1(el: G1Element): G1Element;
+  mul_g2(el: G2Element): G2Element;
   equalTo(key: PrivateKey): boolean;
   delete(): void;
 }

--- a/js-bindings/jsbindings.cpp
+++ b/js-bindings/jsbindings.cpp
@@ -69,16 +69,22 @@ EMSCRIPTEN_BINDINGS(blsjs) {
         .function("deepcopy", &G1ElementWrapper::Deepcopy)
         .function("get_fingerprint", &G1ElementWrapper::GetFingerprint)
         .function("add", &G1ElementWrapper::Add)
-        .function("mul", &G1ElementWrapper::Mul);
+        .function("mul", &G1ElementWrapper::Mul)
+        .function("eqaulTo", &G1ElementWrapper::EqualTo);
 
     class_<G2ElementWrapper>("G2Element")
         .class_property("SIZE", &G2ElementWrapper::SIZE)
         .constructor<>()
+        .class_function("fromG2Element", &G2ElementWrapper::FromG2Element)
         .class_function("fromBytes", &G2ElementWrapper::FromBytes)
+        .class_function("aggregateSigs", &G2ElementWrapper::AggregateSigs)
         .class_function("generator", &G2ElementWrapper::Generator)
         .function("serialize", &G2ElementWrapper::Serialize)
         .function("negate", &G2ElementWrapper::Negate)
-        .function("deepcopy", &G2ElementWrapper::Deepcopy);
+        .function("deepcopy", &G2ElementWrapper::Deepcopy)
+        .function("add", &G2ElementWrapper::Add)
+        .function("mul", &G2ElementWrapper::Mul)
+        .function("eqaulTo", &G2ElementWrapper::EqualTo);
 
     class_<PrivateKeyWrapper>("PrivateKey")
         .class_property("PRIVATE_KEY_SIZE", &PrivateKeyWrapper::PRIVATE_KEY_SIZE)
@@ -86,7 +92,11 @@ EMSCRIPTEN_BINDINGS(blsjs) {
         .class_function("aggregate", &PrivateKeyWrapper::Aggregate)
         .function("deepcopy", &PrivateKeyWrapper::Deepcopy)
         .function("serialize", &PrivateKeyWrapper::Serialize)
-        .function("get_g1", &PrivateKeyWrapper::GetG1);
+        .function("get_g1", &PrivateKeyWrapper::GetG1)
+        .function("get_g2", &PrivateKeyWrapper::GetG2)
+        .function("mul_g1", &PrivateKeyWrapper::MulG1)
+        .function("mul_g2", &PrivateKeyWrapper::MulG2)
+        .function("eqaulTo", &PrivateKeyWrapper::EqualTo);
 
     class_<BignumWrapper>("Bignum")
         .class_function("fromString", &BignumWrapper::FromString)

--- a/js-bindings/jsbindings.cpp
+++ b/js-bindings/jsbindings.cpp
@@ -62,7 +62,7 @@ EMSCRIPTEN_BINDINGS(blsjs) {
     class_<G1ElementWrapper>("G1Element")
         .class_property("SIZE", &G1ElementWrapper::SIZE)
         .constructor<>()
-        .class_function("fromBytes", &G1ElementWrapper::FromBytes)
+        .class_function("from_bytes", &G1ElementWrapper::FromBytes)
         .class_function("generator", &G2ElementWrapper::Generator)
         .function("serialize", &G1ElementWrapper::Serialize)
         .function("negate", &G1ElementWrapper::Negate)
@@ -70,25 +70,25 @@ EMSCRIPTEN_BINDINGS(blsjs) {
         .function("get_fingerprint", &G1ElementWrapper::GetFingerprint)
         .function("add", &G1ElementWrapper::Add)
         .function("mul", &G1ElementWrapper::Mul)
-        .function("equalTo", &G1ElementWrapper::EqualTo);
+        .function("equal_to", &G1ElementWrapper::EqualTo);
 
     class_<G2ElementWrapper>("G2Element")
         .class_property("SIZE", &G2ElementWrapper::SIZE)
         .constructor<>()
-        .class_function("fromG2Element", &G2ElementWrapper::FromG2Element)
-        .class_function("fromBytes", &G2ElementWrapper::FromBytes)
-        .class_function("aggregateSigs", &G2ElementWrapper::AggregateSigs)
+        .class_function("from_g2", &G2ElementWrapper::FromG2Element)
+        .class_function("from_bytes", &G2ElementWrapper::FromBytes)
+        .class_function("aggregate_sigs", &G2ElementWrapper::AggregateSigs)
         .class_function("generator", &G2ElementWrapper::Generator)
         .function("serialize", &G2ElementWrapper::Serialize)
         .function("negate", &G2ElementWrapper::Negate)
         .function("deepcopy", &G2ElementWrapper::Deepcopy)
         .function("add", &G2ElementWrapper::Add)
         .function("mul", &G2ElementWrapper::Mul)
-        .function("equalTo", &G2ElementWrapper::EqualTo);
+        .function("equal_to", &G2ElementWrapper::EqualTo);
 
     class_<PrivateKeyWrapper>("PrivateKey")
         .class_property("PRIVATE_KEY_SIZE", &PrivateKeyWrapper::PRIVATE_KEY_SIZE)
-        .class_function("fromBytes", &PrivateKeyWrapper::FromBytes)
+        .class_function("from_bytes", &PrivateKeyWrapper::FromBytes)
         .class_function("aggregate", &PrivateKeyWrapper::Aggregate)
         .function("deepcopy", &PrivateKeyWrapper::Deepcopy)
         .function("serialize", &PrivateKeyWrapper::Serialize)
@@ -96,14 +96,14 @@ EMSCRIPTEN_BINDINGS(blsjs) {
         .function("get_g2", &PrivateKeyWrapper::GetG2)
         .function("mul_g1", &PrivateKeyWrapper::MulG1)
         .function("mul_g2", &PrivateKeyWrapper::MulG2)
-        .function("equalTo", &PrivateKeyWrapper::EqualTo);
+        .function("equal_to", &PrivateKeyWrapper::EqualTo);
 
     class_<BignumWrapper>("Bignum")
-        .class_function("fromString", &BignumWrapper::FromString)
+        .class_function("from_string", &BignumWrapper::FromString)
         .function("toString", &BignumWrapper::ToString);
 
     class_<UtilWrapper>("Util")
         .class_function("hash256", &UtilWrapper::Hash256)
-        .class_function("hexStr", &UtilWrapper::HexStr);
+        .class_function("hex_str", &UtilWrapper::HexStr);
 };
 }  // namespace js_wrappers

--- a/js-bindings/jsbindings.cpp
+++ b/js-bindings/jsbindings.cpp
@@ -89,6 +89,7 @@ EMSCRIPTEN_BINDINGS(blsjs) {
     class_<PrivateKeyWrapper>("PrivateKey")
         .class_property("PRIVATE_KEY_SIZE", &PrivateKeyWrapper::PRIVATE_KEY_SIZE)
         .class_function("from_bytes", &PrivateKeyWrapper::FromBytes)
+        .class_function("fromBytes", &PrivateKeyWrapper::FromBytes) // Cancel to remove this for compatibility
         .class_function("aggregate", &PrivateKeyWrapper::Aggregate)
         .function("deepcopy", &PrivateKeyWrapper::Deepcopy)
         .function("serialize", &PrivateKeyWrapper::Serialize)

--- a/js-bindings/jsbindings.cpp
+++ b/js-bindings/jsbindings.cpp
@@ -70,7 +70,7 @@ EMSCRIPTEN_BINDINGS(blsjs) {
         .function("get_fingerprint", &G1ElementWrapper::GetFingerprint)
         .function("add", &G1ElementWrapper::Add)
         .function("mul", &G1ElementWrapper::Mul)
-        .function("eqaulTo", &G1ElementWrapper::EqualTo);
+        .function("equalTo", &G1ElementWrapper::EqualTo);
 
     class_<G2ElementWrapper>("G2Element")
         .class_property("SIZE", &G2ElementWrapper::SIZE)
@@ -84,7 +84,7 @@ EMSCRIPTEN_BINDINGS(blsjs) {
         .function("deepcopy", &G2ElementWrapper::Deepcopy)
         .function("add", &G2ElementWrapper::Add)
         .function("mul", &G2ElementWrapper::Mul)
-        .function("eqaulTo", &G2ElementWrapper::EqualTo);
+        .function("equalTo", &G2ElementWrapper::EqualTo);
 
     class_<PrivateKeyWrapper>("PrivateKey")
         .class_property("PRIVATE_KEY_SIZE", &PrivateKeyWrapper::PRIVATE_KEY_SIZE)
@@ -96,7 +96,7 @@ EMSCRIPTEN_BINDINGS(blsjs) {
         .function("get_g2", &PrivateKeyWrapper::GetG2)
         .function("mul_g1", &PrivateKeyWrapper::MulG1)
         .function("mul_g2", &PrivateKeyWrapper::MulG2)
-        .function("eqaulTo", &PrivateKeyWrapper::EqualTo);
+        .function("equalTo", &PrivateKeyWrapper::EqualTo);
 
     class_<BignumWrapper>("Bignum")
         .class_function("fromString", &BignumWrapper::FromString)

--- a/js-bindings/jsbindings.cpp
+++ b/js-bindings/jsbindings.cpp
@@ -62,6 +62,7 @@ EMSCRIPTEN_BINDINGS(blsjs) {
     class_<G1ElementWrapper>("G1Element")
         .class_property("SIZE", &G1ElementWrapper::SIZE)
         .constructor<>()
+        .class_function("fromBytes", &G1ElementWrapper::FromBytes) // Not removing this for compatibility
         .class_function("from_bytes", &G1ElementWrapper::FromBytes)
         .class_function("generator", &G2ElementWrapper::Generator)
         .function("serialize", &G1ElementWrapper::Serialize)
@@ -75,8 +76,9 @@ EMSCRIPTEN_BINDINGS(blsjs) {
     class_<G2ElementWrapper>("G2Element")
         .class_property("SIZE", &G2ElementWrapper::SIZE)
         .constructor<>()
-        .class_function("from_g2", &G2ElementWrapper::FromG2Element)
+        .class_function("fromBytes", &G2ElementWrapper::FromBytes) // Not removing this for compatibility
         .class_function("from_bytes", &G2ElementWrapper::FromBytes)
+        .class_function("from_g2", &G2ElementWrapper::FromG2Element)
         .class_function("aggregate_sigs", &G2ElementWrapper::AggregateSigs)
         .class_function("generator", &G2ElementWrapper::Generator)
         .function("serialize", &G2ElementWrapper::Serialize)
@@ -88,8 +90,8 @@ EMSCRIPTEN_BINDINGS(blsjs) {
 
     class_<PrivateKeyWrapper>("PrivateKey")
         .class_property("PRIVATE_KEY_SIZE", &PrivateKeyWrapper::PRIVATE_KEY_SIZE)
+        .class_function("fromBytes", &PrivateKeyWrapper::FromBytes) // Not removing this for compatibility
         .class_function("from_bytes", &PrivateKeyWrapper::FromBytes)
-        .class_function("fromBytes", &PrivateKeyWrapper::FromBytes) // Cancel to remove this for compatibility
         .class_function("aggregate", &PrivateKeyWrapper::Aggregate)
         .function("deepcopy", &PrivateKeyWrapper::Deepcopy)
         .function("serialize", &PrivateKeyWrapper::Serialize)

--- a/js-bindings/jsbindings.cpp
+++ b/js-bindings/jsbindings.cpp
@@ -93,6 +93,7 @@ EMSCRIPTEN_BINDINGS(blsjs) {
         .function("toString", &BignumWrapper::ToString);
 
     class_<UtilWrapper>("Util")
-        .class_function("hash256", &UtilWrapper::Hash256);
+        .class_function("hash256", &UtilWrapper::Hash256)
+        .class_function("hexStr", &UtilWrapper::HexStr);
 };
 }  // namespace js_wrappers

--- a/js-bindings/jsbindings.cpp
+++ b/js-bindings/jsbindings.cpp
@@ -102,6 +102,7 @@ EMSCRIPTEN_BINDINGS(blsjs) {
         .function("equal_to", &PrivateKeyWrapper::EqualTo);
 
     class_<BignumWrapper>("Bignum")
+        .class_function("fromString", &BignumWrapper::FromString) // Not removing this for compatibility
         .class_function("from_string", &BignumWrapper::FromString)
         .function("toString", &BignumWrapper::ToString);
 

--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-signatures",
-  "version": "0.2.0",
+  "version": "0.2.1-beta.0",
   "description": "The most advanced BLS library for JavaScript",
   "main": "blsjs.js",
   "types": "blsjs.d.ts",

--- a/js-bindings/wrappers/G1ElementWrapper.cpp
+++ b/js-bindings/wrappers/G1ElementWrapper.cpp
@@ -54,6 +54,10 @@ G1ElementWrapper G1ElementWrapper::Mul(const BignumWrapper &other) {
     return G1ElementWrapper(GetWrappedInstance() * factor);
 }
 
+bool G1ElementWrapper::EqualTo(const G1ElementWrapper &others) {
+    return GetWrappedInstance() == others.GetWrappedInstance();
+}
+
 G1ElementWrapper G1ElementWrapper::Negate() {
     return G1ElementWrapper(GetWrappedInstance().Negate());
 }

--- a/js-bindings/wrappers/G1ElementWrapper.h
+++ b/js-bindings/wrappers/G1ElementWrapper.h
@@ -40,6 +40,8 @@ public:
 
     G1ElementWrapper Mul(const BignumWrapper &other);
 
+    bool EqualTo(const G1ElementWrapper &others);
+
     G1ElementWrapper Negate();
 
     G1ElementWrapper Deepcopy();

--- a/js-bindings/wrappers/G2ElementWrapper.cpp
+++ b/js-bindings/wrappers/G2ElementWrapper.cpp
@@ -62,4 +62,22 @@ G2ElementWrapper G2ElementWrapper::Negate() {
 val G2ElementWrapper::Serialize() const {
     return helpers::toUint8Array(wrapped.Serialize());
 }
+
+G2ElementWrapper G2ElementWrapper::Add(const G2ElementWrapper& other) {
+    return G2ElementWrapper(GetWrappedInstance() + other.GetWrappedInstance());
+}
+
+G2ElementWrapper G2ElementWrapper::Mul(const BignumWrapper& other) {
+    bn_t factor;
+    // Since the type of bn_t is bn_st[0], we can do this dance to make a
+    // temporary copy of the struct itself to hand to G2ElementWrapper's
+    // multiply.  The type was clearly intended to by by-value in argument lists
+    // (degrade to ptr) but value semantics in C++ complicates matters.
+    factor[0] = *(&other.GetWrappedInstance());
+    return G2ElementWrapper(GetWrappedInstance() * factor);
+}
+
+bool G2ElementWrapper::EqualTo(const G2ElementWrapper& others) {
+    return GetWrappedInstance() == others.GetWrappedInstance();
+}
 }  // namespace js_wrappers

--- a/js-bindings/wrappers/G2ElementWrapper.h
+++ b/js-bindings/wrappers/G2ElementWrapper.h
@@ -42,6 +42,12 @@ class G2ElementWrapper : public JSWrapper<G2Element> {
     G2ElementWrapper Negate();
 
     val Serialize() const;
+
+    G2ElementWrapper Add(const G2ElementWrapper &other);
+
+    G2ElementWrapper Mul(const BignumWrapper &other);
+
+    bool EqualTo(const G2ElementWrapper &others);
 };
 }  // namespace js_wrappers
 

--- a/js-bindings/wrappers/G2ElementWrapper.h
+++ b/js-bindings/wrappers/G2ElementWrapper.h
@@ -17,6 +17,7 @@
 
 #include "../helpers.h"
 #include "JSWrapper.h"
+#include "BignumWrapper.h"
 
 namespace js_wrappers {
 class G2ElementWrapper : public JSWrapper<G2Element> {

--- a/js-bindings/wrappers/PrivateKeyWrapper.cpp
+++ b/js-bindings/wrappers/PrivateKeyWrapper.cpp
@@ -54,4 +54,26 @@ G1ElementWrapper PrivateKeyWrapper::GetG1() const {
     G1Element pk = wrapped.GetG1Element();
     return G1ElementWrapper(pk);
 }
+
+G2ElementWrapper PrivateKeyWrapper::GetG2() const {
+    G2Element sk = wrapped.GetG2Element();
+    return G2ElementWrapper(sk);
+}
+
+G2ElementWrapper PrivateKeyWrapper::GetG2Power(const G2ElementWrapper& element) const {
+    return G2ElementWrapper(GetWrappedInstance().GetG2Power(element.GetWrappedInstance()));
+}
+
+G1ElementWrapper PrivateKeyWrapper::MulG1(const G1ElementWrapper& other) {
+    return G1ElementWrapper(GetWrappedInstance() * other.GetWrappedInstance());
+}
+
+G2ElementWrapper PrivateKeyWrapper::MulG2(const G2ElementWrapper& other) {
+    return G2ElementWrapper(GetWrappedInstance() * other.GetWrappedInstance());
+}
+
+bool PrivateKeyWrapper::EqualTo(const PrivateKeyWrapper& others) {
+    return GetWrappedInstance() == others.GetWrappedInstance();
+}
+
 }  // namespace js_wrappers

--- a/js-bindings/wrappers/PrivateKeyWrapper.h
+++ b/js-bindings/wrappers/PrivateKeyWrapper.h
@@ -38,6 +38,16 @@ class PrivateKeyWrapper : public JSWrapper<PrivateKey> {
     PrivateKeyWrapper Deepcopy();
 
     G1ElementWrapper GetG1() const;
+
+    G2ElementWrapper GetG2() const;
+
+    G2ElementWrapper GetG2Power(const G2ElementWrapper &element) const;
+
+    G1ElementWrapper MulG1(const G1ElementWrapper &other);
+
+    G2ElementWrapper MulG2(const G2ElementWrapper &other);
+
+    bool EqualTo(const PrivateKeyWrapper &others);
 };
 }  // namespace js_wrappers
 

--- a/js-bindings/wrappers/UtilWrapper.cpp
+++ b/js-bindings/wrappers/UtilWrapper.cpp
@@ -21,4 +21,8 @@ val UtilWrapper::Hash256(val msg) {
     Util::Hash256(&output[0], (const uint8_t *)bytes.data(), bytes.size());
     return helpers::toUint8Array(&output[0], output.size());
 }
+std::string UtilWrapper::HexStr(val msg) {
+    std::vector<uint8_t> bytes = helpers::toVector(msg);
+    return Util::HexStr(bytes);
+}
 }  // namespace js_wrappers

--- a/js-bindings/wrappers/UtilWrapper.h
+++ b/js-bindings/wrappers/UtilWrapper.h
@@ -22,6 +22,7 @@ namespace js_wrappers {
 class UtilWrapper : public JSWrapper<Util> {
 public:
     static val Hash256(val message);
+    static std::string HexStr(val message);
 };
 }  // namespace js_wrappers
 


### PR DESCRIPTION
Related to #220 

Typings for js-binding is broken and too old.
I've updated type declarations and added some methods which should be exposed.

# Important Change note

## Updated to the latest type definition as of the latest `jsbindings.cpp`.
See diffs in this PR.

## Set npm module version to `0.2.1-beta.0`
This PR does not include test specs corresponding to the updates.  
So merging this PR doesn't mean it's OK to publish to npm. Just a beta version at the best.
I decided to leave test specs untouched because I think my updates need to be cross checked by creating new test specs by someone else.
So please add test specs after this PR is merged to main branch.
```javascript
// bls-signatures/js-bindings/package.json
{
  "name": "bls-signatures",
  "version": "0.2.1-beta.0", // <- Set to 0.2.1-beta.0 from 0.2.0.
  ...
}
```

## ~~Changed a camelCased method name to snake_case~~
~~More specifically, I changed method name `fromBytes` to `from_bytes`. (python bindings is using name `from_bytes`)~~
~~This might be an innocent breaking change for existings npm users.~~
~~Maybe this change should be reverted. Please give me your opinions.~~
I once renamed `fromBytes` to `from_bytes` for js-binding, but in order to avoid breaking change,
I decided to just add `from_bytes` and not remove `fromBytes` method.

## Exposed several method for usefulness
- G1Element.equal_to
- G2Element.from_g2
- G2Element.aggregate_sigs
- G2Element.add
- G2Element.mul
- G2Element.equal_to
- PrivateKey.get_g2
- PrivateKey.mul_g1
- PrivateKey.mul_g2
- PrivateKey.equal_to
- Util.hex_str