### PR TITLE
Fixed wrong toolchain file path in js_build.sh

### DIFF
--- a/js_build.sh
+++ b/js_build.sh
@@ -5,5 +5,5 @@ git submodule update --init --recursive
 mkdir js_build
 cd js_build
 
-cmake ../ -DCMAKE_TOOLCHAIN_FILE=$(realpath $(which emcc))/cmake/Modules/Platform/Emscripten.cmake
+cmake ../ -DCMAKE_TOOLCHAIN_FILE=$(dirname $(realpath $(which emcc)))/cmake/Modules/Platform/Emscripten.cmake
 cmake --build . --


### PR DESCRIPTION
## The problem
Failed to build js-bindings via `js_build.sh`

## Steps to reproduce
```shell
$ git clone https://github.com/Chia-Network/bls-signatures
$ cd bls-signatures
$ ./js_build.sh

CMake Error at /usr/share/cmake-3.16/Modules/CMakeDetermineSystem.cmake:99 (message):
  Could not find toolchain file:
  /PATH_TO_EMSDK/emsdk/upstream/emscripten/emcc/cmake/Modules/Platform/Emscripten.cmake
Call Stack (most recent call first):
  CMakeLists.txt:12 (project)
```

## Root cause
```shell
# ...
cmake ../ -DCMAKE_TOOLCHAIN_FILE=$(realpath $(which emcc))/cmake/Modules/Platform/Emscripten.cmake
# ...
```
The Emscripten root specified in `CMAKE_TOOLCHAIN_FILE` is wrong.
`$(realpath $(which emcc))` should be `$(dirname $(realpath $(which emcc)))`

## Quick example
https://youtu.be/rQlBDzBLP-4
