### PR TITLE
Add MacOS, Python, Javascript tests to Relic Nightly

### DIFF
--- a/.github/workflows/relic-nightly.yml
+++ b/.github/workflows/relic-nightly.yml
@@ -1,4 +1,4 @@
-name:  Build and Test C++ with Relic Nightly
+name:  Build and Test with Relic Nightly
 
 on:
   schedule:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build and Test C++ with Relic Nightly
+    name: Build and Test with Relic Nightly
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/relic-nightly.yml
+++ b/.github/workflows/relic-nightly.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
     - name: Cancel previous runs on the same branch
@@ -55,3 +55,31 @@ jobs:
         cmake --build . -- -j 6
         echo "Running ./src/runtest"
         ./src/runtest
+
+    - name: Mac OS build C++ and test
+      if: startsWith(matrix.os, 'macos')
+      run: |
+        ls -l
+        export MACOSX_DEPLOYMENT_TARGET=10.14
+        export CIBUILDWHEEL=1
+        export RELIC_MAIN=1
+        mkdir -p build
+        ls -l build
+        cd build
+        cmake ../
+        cmake --build . -- -j 6
+        echo "Running ./src/runtest"
+        ./src/runtest
+
+    - name: Test pure python implementation
+      run: |
+        python python-impl/impl-test.py
+
+    - name: Install emsdk
+      uses: mymindstorm/setup-emsdk@v9
+
+    - name: Test javascript bindings
+      run: |
+        emcc -v
+        sh emsdk_build.sh
+        sh js_test.sh

--- a/.github/workflows/relic-nightly.yml
+++ b/.github/workflows/relic-nightly.yml
@@ -86,5 +86,6 @@ jobs:
     - name: Test javascript bindings
       run: |
         emcc -v
+        export RELIC_MAIN=1
         sh emsdk_build.sh
         sh js_test.sh

--- a/.github/workflows/relic-nightly.yml
+++ b/.github/workflows/relic-nightly.yml
@@ -71,6 +71,11 @@ jobs:
         echo "Running ./src/runtest"
         ./src/runtest
 
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+        python-version: '3.8'
+
     - name: Test pure python implementation
       run: |
         python python-impl/impl-test.py

--- a/js-bindings/wrappers/BignumWrapper.cpp
+++ b/js-bindings/wrappers/BignumWrapper.cpp
@@ -17,7 +17,7 @@
 
 namespace js_wrappers {
 Bignum::Bignum() {
-    bn_init(&content, 1);
+    bn_make(&content, 1);
 }
 
 Bignum::~Bignum() {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 if (DEFINED ENV{RELIC_MAIN})
   set(RELIC_GIT_TAG "origin/main")
 else ()
-  set(RELIC_GIT_TAG "1885ae3b681c423c72b65ce1fe70910142cf941c")
+  set(RELIC_GIT_TAG "e6209fd80e07203b865983faee635fa1f85d6c9f")
 endif ()
 
 message(STATUS "Relic will be built from: ${RELIC_GIT_TAG}")


### PR DESCRIPTION
This will now test MacOS, Python, Javascript in addition to the C++ on Ubuntu against Relic/main every night.

It moves the regular Relic build has to the same one proposed in PR #244 