### PR TITLE
Update Relic for G1 fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 if (DEFINED ENV{RELIC_MAIN})
   set(RELIC_GIT_TAG "origin/main")
 else ()
-  set(RELIC_GIT_TAG "1620a03b388e50acd68ed9c88d7cd82ec5490ce4")
+  set(RELIC_GIT_TAG "e9948b7041c7aa9d6d368d3fedc8496020d8b48f")
 endif ()
 
 message(STATUS "Relic will be built from: ${RELIC_GIT_TAG}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 if (DEFINED ENV{RELIC_MAIN})
   set(RELIC_GIT_TAG "origin/main")
 else ()
-  set(RELIC_GIT_TAG "e6209fd80e07203b865983faee635fa1f85d6c9f")
+  set(RELIC_GIT_TAG "1620a03b388e50acd68ed9c88d7cd82ec5490ce4")
 endif ()
 
 message(STATUS "Relic will be built from: ${RELIC_GIT_TAG}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 if (DEFINED ENV{RELIC_MAIN})
   set(RELIC_GIT_TAG "origin/main")
 else ()
-  set(RELIC_GIT_TAG "e9948b7041c7aa9d6d368d3fedc8496020d8b48f")
+  set(RELIC_GIT_TAG "7ed8e702db74d5d5a83b0bfaf9ee8e33a70e36ed")
 endif ()
 
 message(STATUS "Relic will be built from: ${RELIC_GIT_TAG}")

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -58,6 +58,7 @@ G1Element G1Element::FromBytes(const Bytes& bytes)
         }
     }
     g1_read_bin(ele.p, buffer, G1Element::SIZE + 1);
+    BLS::CheckRelicErrors();
     ele.CheckValid();
     return ele;
 }
@@ -243,6 +244,7 @@ G2Element G2Element::FromBytes(const Bytes& bytes)
     }
 
     g2_read_bin(ele.q, buffer, G2Element::SIZE + 1);
+    BLS::CheckRelicErrors();
     ele.CheckValid();
     return ele;
 }


### PR DESCRIPTION
Recent changes to Relic caused an issue that @guidovranken flagged and @dfaranha fixed - #247 

This PR moves the targetted/pinned version of Relic to the fixed Relic commit - https://github.com/relic-toolkit/relic/commit/7ed8e702db74d5d5a83b0bfaf9ee8e33a70e36ed as requested by @dfaranha 