### PR TITLE
Add fix for RELIC parsing invalid inputs.

### DIFF
--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -58,6 +58,7 @@ G1Element G1Element::FromBytes(const Bytes& bytes)
         }
     }
     g1_read_bin(ele.p, buffer, G1Element::SIZE + 1);
+    BLS::CheckRelicErrors();
     ele.CheckValid();
     return ele;
 }
@@ -243,6 +244,7 @@ G2Element G2Element::FromBytes(const Bytes& bytes)
     }
 
     g2_read_bin(ele.q, buffer, G2Element::SIZE + 1);
+    BLS::CheckRelicErrors();
     ele.CheckValid();
     return ele;
 }


### PR DESCRIPTION
This patch handles RELIC errors when invalid inputs are provided.