### PR TITLE
Make string output of the pk consistent wrt leading 0

### DIFF
--- a/python-impl/private_key.py
+++ b/python-impl/private_key.py
@@ -51,10 +51,10 @@ class PrivateKey:
         return self.PRIVATE_KEY_SIZE
 
     def __str__(self):
-        return "PrivateKey(" + hex(self.value) + ")"
+        return "PrivateKey(0x" + bytes(self).hex() + ")"
 
     def __repr__(self):
-        return "PrivateKey(" + hex(self.value) + ")"
+        return "PrivateKey(0x" + bytes(self).hex() + ")"
 
     @staticmethod
     def aggregate(private_keys):


### PR DESCRIPTION
This is a minor change. When converted to hex for display purposes - the python hex() call will remove leading zeros. This can lead to some minor inconsistency between the display of the PrivateKey and the display of the bytes. For example:

`print(f"{key}")` would display `PrivateKey(0xba5a1381d6718d15b6e3122344c3f71ab3f6f7d12dfc7b8a6856b9404007a04)`

`print(f"{bytes(key).hex()}")` would display `0x0ba5a1381d6718d15b6e3122344c3f71ab3f6f7d12dfc7b8a6856b9404007a04`

This PR resolves this by making sure the string representation will match the bytes representation