### PR TITLE
fix some gcc compiler warnings when using -Wsign-compare

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -60,7 +60,7 @@ class Util {
     static std::string HexStr(const uint8_t* data, size_t len) {
         std::stringstream s;
         s << std::hex;
-        for (int i=0; i < len; ++i)
+        for (size_t i=0; i < len; ++i)
             s << std::setw(2) << std::setfill('0') << static_cast<int>(data[i]);
         return s.str();
     }
@@ -68,7 +68,7 @@ class Util {
     static std::string HexStr(const std::vector<uint8_t> &data) {
         std::stringstream s;
         s << std::hex;
-        for (int i=0; i < data.size(); ++i)
+        for (size_t i=0; i < data.size(); ++i)
             s << std::setw(2) << std::setfill('0') << static_cast<int>(data[i]);
         return s.str();
     }


### PR DESCRIPTION
util.hpp: In static member function ‘static std::string bls::Util::HexStr(const uint8_t*, size_t)’:
util.hpp:62:25: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   62 |         for (int i=0; i < len; ++i)