### PR TITLE
Provide parameter to FE.zero

### DIFF
--- a/python-impl/ec.py
+++ b/python-impl/ec.py
@@ -347,7 +347,7 @@ def add_points(p1: AffinePoint, p2: AffinePoint, ec=default_ec, FE=Fq) -> Affine
     if p1 == p2:
         return double_point(p1, ec, FE)
     if p1.x == p2.x:
-        return AffinePoint(FE.zero(), FE.zero(), True, ec)
+        return AffinePoint(FE.zero(ec.q), FE.zero(ec.q), True, ec)
 
     x1, y1 = p1.x, p1.y
     x2, y2 = p2.x, p2.y


### PR DESCRIPTION
In the pure-Python implementation, adding points which lead to the infinity triggers an exception:

    Traceback (most recent call last):
      File "bls-signatures/python-impl/ec.py", line 55, in __add__
        return add_points(self, other, self.ec, self.FE)
      File "bls-signatures/python-impl/ec.py", line 350, in add_points
        return AffinePoint(FE.zero(), FE.zero(), True, ec)
    TypeError: zero() missing 1 required positional argument: 'Q'

This is because `FE.zero` needs to be called with `ec.q`.

Add the missing parameter to the call.