### PR TITLE
Bug: invalid G1 and G2 cached in PrivateKey

### DIFF
--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -87,6 +87,7 @@ PrivateKey& PrivateKey::operator=(const PrivateKey& other)
 {
     CheckKeyData();
     other.CheckKeyData();
+    InvalidateCaches();
     bn_copy(keydata, other.keydata);
     return *this;
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -69,7 +69,7 @@ TEST_CASE("class PrivateKey") {
         REQUIRE(pk2.GetG2Element().IsValid()); // cache previous g2
         pk2 = pk1;
         REQUIRE(pk1 == pk2);
-        REQUIRE(pk1.GetG1Element() == pk2.GetG1Element());  // currently failing
+        REQUIRE(pk1.GetG1Element() == pk2.GetG1Element());
         REQUIRE(pk1.GetG2Element() == pk2.GetG2Element());
         REQUIRE(pk3 != pk2);
     }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -65,8 +65,12 @@ TEST_CASE("class PrivateKey") {
         REQUIRE(!pk3.IsZero());
         REQUIRE(pk1 != pk2);
         REQUIRE(pk3 == pk2);
+        REQUIRE(pk2.GetG1Element().IsValid()); // cache previous g1
+        REQUIRE(pk2.GetG2Element().IsValid()); // cache previous g2
         pk2 = pk1;
         REQUIRE(pk1 == pk2);
+        REQUIRE(pk1.GetG1Element() == pk2.GetG1Element());  // currently failing
+        REQUIRE(pk1.GetG2Element() == pk2.GetG2Element());
         REQUIRE(pk3 != pk2);
     }
     SECTION("Move {constructor|assignment operator}") {


### PR DESCRIPTION
Introduced in #168.
The copy assignment operator does not invalidate the caches.
This could dangerously lead to situations where a `PrivateKey` returns wrong G1/G2 elements (if they were cached before the copy).