### PR TITLE
Also build Python 3.10 wheels

### DIFF
--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -50,6 +50,7 @@ jobs:
         python -m cibuildwheel --output-dir dist
       env:
         CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
+        CIBW_SKIP: '*-musllinux_*'
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
         CIBW_BUILD_VERBOSITY_LINUX: 0
         CIBW_BEFORE_BUILD_LINUX: >

--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -30,7 +30,7 @@ jobs:
         python3 -m venv venv
         source venv/bin/activate
         python -m pip install --upgrade pip
-        python -m pip install cibuildwheel==1.10.0
+        python -m pip install cibuildwheel==2.2.2
 
     - name: Lint source with flake8
       run: |
@@ -49,8 +49,7 @@ jobs:
         source venv/bin/activate
         python -m cibuildwheel --output-dir dist
       env:
-        # build python 3.7 and 3.8
-        CIBW_BUILD: cp37-* cp38-* cp39-*
+        CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
         CIBW_BUILD_VERBOSITY_LINUX: 0
         CIBW_BEFORE_BUILD_LINUX: >

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4,13 +4,12 @@ on: [push, pull_request]
 
 jobs:
   build_wheels:
-    name: Build and Test on ${{ matrix.os }} CPython ${{ matrix.python }}
+    name: Build and Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - name: Cancel previous runs on the same branch
@@ -25,7 +24,7 @@ jobs:
     - uses: actions/setup-python@v2
       name: Install Python
       with:
-        python-version: ${{ matrix.python }}
+        python-version: '3.8'
 
     - name: Ubuntu build C++ and test with valgrind
       if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build_wheels:
-    name: Build and Test on ${{ matrix.os }}
+    name: Build and Test on ${{ matrix.os }} CPython ${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
+        python: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - name: Cancel previous runs on the same branch
@@ -24,7 +25,7 @@ jobs:
     - uses: actions/setup-python@v2
       name: Install Python
       with:
-        python-version: '3.8'
+        python-version: ${{ matrix.python }}
 
     - name: Ubuntu build C++ and test with valgrind
       if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -54,7 +54,7 @@ jobs:
         CIBW_BUILD_VERBOSITY_LINUX: 0
         CIBW_BUILD_VERBOSITY_WINDOWS: 0
         CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
-        CIBW_SKIP: '*-manylinux_i686 *-win32'
+        CIBW_SKIP: '*-manylinux_i686 *-win32 *-musllinux_*'
         CIBW_TEST_REQUIRES: pytest
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
         CIBW_ENVIRONMENT_LINUX: "PATH=/project/cmake-3.17.3-Linux-`uname -m`/bin:$PATH"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -53,8 +53,7 @@ jobs:
         CIBW_BUILD_VERBOSITY_MACOS: 0
         CIBW_BUILD_VERBOSITY_LINUX: 0
         CIBW_BUILD_VERBOSITY_WINDOWS: 0
-        # Python 3.7 and 3.8
-        CIBW_BUILD: cp37-* cp38-* cp39-*
+        CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
         CIBW_SKIP: '*-manylinux_i686 *-win32'
         CIBW_TEST_REQUIRES: pytest
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -46,7 +46,7 @@ jobs:
         python -m build --sdist --outdir dist .
 
     - name: Build ${{ matrix.os }} wheels and test
-      uses: joerick/cibuildwheel@v1.10.0
+      uses: joerick/cibuildwheel@v2.2.2
       with:
         output-dir: dist
       env:


### PR DESCRIPTION
* Update cibuildwheel to v2.2.2
* Build wheels for 3.10 (except M1)

Draft for:
- [x] consider abi3
  - It isn't apparent that pybind11 supports the stable ABIs.
- [x] break apart
- [x] ~option version in test job names~
