### PR TITLE
Actually test Relic main nightly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,11 @@ FetchContent_MakeAvailable(Sodium)
 
 if (DEFINED ENV{RELIC_MAIN})
   set(RELIC_GIT_TAG "origin/main")
-  set(RELIC_REPOSITORY "https://github.com/relic-toolkit/relic.git"
+  set(RELIC_REPOSITORY "https://github.com/relic-toolkit/relic.git")
 else ()
   # This is currently anchored to upstream aecdcae7956f542fbee2392c1f0feb0a8ac41dc5
   set(RELIC_GIT_TAG "1d98e5abf3ca5b14fd729bd5bcced88ea70ecfd7")
-  set(RELIC_REPOSITORY "https://github.com/Chia-Network/relic.git"
+  set(RELIC_REPOSITORY "https://github.com/Chia-Network/relic.git")
 endif ()
 
 message(STATUS "Relic will be built from: ${RELIC_GIT_TAG} and repository ${RELIC_REPOSITORY}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,11 @@ FetchContent_MakeAvailable(Sodium)
 
 if (DEFINED ENV{RELIC_MAIN})
   set(RELIC_GIT_TAG "origin/main")
-  set(RELIC_REPOSITORY "https://github.com/Chia-Network/relic.git"
+  set(RELIC_REPOSITORY "https://github.com/relic-toolkit/relic.git"
 else ()
   # This is currently anchored to upstream aecdcae7956f542fbee2392c1f0feb0a8ac41dc5
   set(RELIC_GIT_TAG "1d98e5abf3ca5b14fd729bd5bcced88ea70ecfd7")
-  set(RELIC_REPOSITORY "https://github.com/relic-toolkit/relic.git"
+  set(RELIC_REPOSITORY "https://github.com/Chia-Network/relic.git"
 endif ()
 
 message(STATUS "Relic will be built from: ${RELIC_GIT_TAG} and repository ${RELIC_REPOSITORY}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,16 +43,18 @@ FetchContent_MakeAvailable(Sodium)
 
 if (DEFINED ENV{RELIC_MAIN})
   set(RELIC_GIT_TAG "origin/main")
+  set(RELIC_REPOSITORY "https://github.com/Chia-Network/relic.git"
 else ()
   # This is currently anchored to upstream aecdcae7956f542fbee2392c1f0feb0a8ac41dc5
   set(RELIC_GIT_TAG "1d98e5abf3ca5b14fd729bd5bcced88ea70ecfd7")
+  set(RELIC_REPOSITORY "https://github.com/relic-toolkit/relic.git"
 endif ()
 
-message(STATUS "Relic will be built from: ${RELIC_GIT_TAG}")
+message(STATUS "Relic will be built from: ${RELIC_GIT_TAG} and repository ${RELIC_REPOSITORY}")
 
 FetchContent_Declare(
   relic
-  GIT_REPOSITORY https://github.com/Chia-Network/relic.git
+  GIT_REPOSITORY ${RELIC_REPOSITORY}
   GIT_TAG ${RELIC_GIT_TAG}
 )
 


### PR DESCRIPTION
Since we're using our fork, the nightly build of Relic at main was not occurring. This adds logic to set the repo to our fork or Relic depending on invocation.

Is the issue that has us using a fork still valid? I'd prefer we pin to Relic proper.