### PR TITLE
Updated the pairings tutorial URL

### DIFF
--- a/python-impl/README.md
+++ b/python-impl/README.md
@@ -5,7 +5,7 @@ as BLS signatures and aggregation. Use for reference / educational purposes only
 
 For an optimized implementation, use the [Python bindings](https://github.com/Chia-Network/bls-signatures/tree/main/python-bindings).
 
-For a good introduction to pairings, read [Pairings for Beginners](http://www.craigcostello.com.au/pairings/PairingsForBeginners.pdf) by Craig Costello.
+For a good introduction to pairings, read [Pairings for Beginners](https://static1.squarespace.com/static/5fdbb09f31d71c1227082339/t/5ff394720493bd28278889c6/1609798774687/PairingsForBeginners.pdf) by Craig Costello.
 
 Map to curve implementation from [Algorand](https://github.com/algorand/bls_sigs_ref/).
 


### PR DESCRIPTION
Updated the URL to [Pairings for Beginners](https://static1.squarespace.com/static/5fdbb09f31d71c1227082339/t/5ff394720493bd28278889c6/1609798774687/PairingsForBeginners.pdf) in the README. Fixes #308.