### PR TITLE
Ms.from bytes unchecked

### DIFF
--- a/python-bindings/pythonbindings.cpp
+++ b/python-bindings/pythonbindings.cpp
@@ -355,6 +355,7 @@ PYBIND11_MODULE(blspy, m)
             return G1Element();
         }))
         .def(py::init(&G1Element::FromByteVector), py::call_guard<py::gil_scoped_release>())
+        .def(py::init(&G1Element::FromByteVectorUnchecked), py::call_guard<py::gil_scoped_release>())
         .def(py::init([](py::int_ pyint) {
             std::vector<uint8_t> buffer(G1Element::SIZE, 0);
             if (_PyLong_AsByteArray(
@@ -399,6 +400,23 @@ PYBIND11_MODULE(blspy, m)
                 std::vector<uint8_t> data(data_ptr, data_ptr + info.size);
                 py::gil_scoped_release release;
                 return G1Element::FromByteVector(data);
+            })
+        .def(
+            "from_bytes_unchecked",
+            [](py::buffer const b) {
+              py::buffer_info info = b.request();
+              if (info.format != py::format_descriptor<uint8_t>::format() ||
+                  info.ndim != 1)
+                  throw std::runtime_error("Incompatible buffer format!");
+
+              if ((int)info.size != G1Element::SIZE) {
+                  throw std::invalid_argument(
+                      "Length of bytes object not equal to G1Element::SIZE");
+              }
+              auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
+              std::vector<uint8_t> data(data_ptr, data_ptr + info.size);
+              py::gil_scoped_release release;
+              return G1Element::FromByteVectorUnchecked(data);
             })
         .def("generator", &G1Element::Generator)
         .def("from_message", py::overload_cast<const std::vector<uint8_t>&, const uint8_t*, int>(&G1Element::FromMessage), py::call_guard<py::gil_scoped_release>())
@@ -480,6 +498,7 @@ PYBIND11_MODULE(blspy, m)
             return G2Element();
         }))
         .def(py::init(&G2Element::FromByteVector), py::call_guard<py::gil_scoped_release>())
+        .def(py::init(&G2Element::FromByteVectorUnchecked), py::call_guard<py::gil_scoped_release>())
         .def(py::init([](py::buffer const b) {
             py::buffer_info info = b.request();
             if (info.format != py::format_descriptor<uint8_t>::format() ||
@@ -524,6 +543,23 @@ PYBIND11_MODULE(blspy, m)
                 std::vector<uint8_t> data(data_ptr, data_ptr + info.size);
                 py::gil_scoped_release release;
                 return G2Element::FromByteVector(data);
+            })
+        .def(
+            "from_bytes_unchecked",
+            [](py::buffer const b) {
+              py::buffer_info info = b.request();
+              if (info.format != py::format_descriptor<uint8_t>::format() ||
+                  info.ndim != 1)
+                  throw std::runtime_error("Incompatible buffer format!");
+
+              if ((int)info.size != G2Element::SIZE) {
+                  throw std::invalid_argument(
+                      "Length of bytes object not equal to G2Element::SIZE");
+              }
+              auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
+              std::vector<uint8_t> data(data_ptr, data_ptr + info.size);
+              py::gil_scoped_release release;
+              return G2Element::FromByteVector(data);
             })
         .def("generator", &G2Element::Generator)
         .def("from_message", py::overload_cast<const std::vector<uint8_t>&, const uint8_t*, int>(&G2Element::FromMessage), py::call_guard<py::gil_scoped_release>())

--- a/python-bindings/test.py
+++ b/python-bindings/test.py
@@ -1,5 +1,6 @@
 # flake8: noqa: E501
 import binascii
+import time
 from copy import deepcopy
 
 from blspy import (
@@ -335,11 +336,46 @@ def test_aggregate_verify_zero_items():
     assert AugSchemeMPL.aggregate_verify([], [], G2Element())
 
 
+def test_invalid_points():
+    sk1 = BasicSchemeMPL.key_gen(b"1" *32)
+    good_point = sk1.get_g1()
+    good_point_bytes = bytes(good_point)
+    start = time.time()
+    for i in range(2000):
+        gp1 = G1Element.from_bytes(good_point_bytes)
+    print(f"from_bytes avg: {(time.time() - start) }")
+
+    start = time.time()
+    for i in range(2000):
+        gp2 = G1Element.from_bytes_unchecked(good_point_bytes)
+    print(f"from_bytes_unchecked avg: {(time.time() - start) }")
+    assert gp1 == gp2
+
+    bad_point_hex: str = "8d5d0fb73b9c92df4eab4216e48c3e358578b4cc30f82c268bd6fef3bd34b558628daf1afef798d4c3b0fcd8b28c8973";
+    try:
+        G1Element.from_bytes(bytes.fromhex(bad_point_hex))
+        assert False
+    except ValueError:
+        pass
+
+    p: G1Element = G1Element.from_bytes_unchecked(bytes.fromhex(bad_point_hex))
+
+    bad_g2_point_hex = "8f2886c94eaeac335c8414cbf14c16681b225380cfee3293becc4531d5b415984b4ea4050d9ecda11fbc21c60627e9d212dfcb17d2b5ae399aa3fbcb099e05baa496b852ad976fb633cc6766b02fca4da549dc063908463b2906ad64e8b310ad"
+
+    try:
+        G2Element.from_bytes(bytes.fromhex(bad_g2_point_hex))
+        assert False
+    except ValueError:
+        pass
+
+
+
 test_schemes()
 test_vectors_invalid()
 test_vectors_valid()
 test_readme()
 test_aggregate_verify_zero_items()
+test_invalid_points()
 
 print("\nAll tests passed.")
 

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -20,7 +20,13 @@ namespace bls {
 
 const size_t G1Element::SIZE;
 
-G1Element G1Element::FromBytes(const Bytes& bytes)
+G1Element G1Element::FromBytes(const Bytes& bytes) {
+    G1Element ele = G1Element::FromBytesUnchecked(bytes);
+    ele.CheckValid();
+    return ele;
+}
+
+G1Element G1Element::FromBytesUnchecked(const Bytes& bytes)
 {
     if (bytes.size() != SIZE) {
         throw std::invalid_argument("G1Element::FromBytes: Invalid size");
@@ -59,7 +65,6 @@ G1Element G1Element::FromBytes(const Bytes& bytes)
     }
     g1_read_bin(ele.p, buffer, G1Element::SIZE + 1);
     BLS::CheckRelicErrors();
-    ele.CheckValid();
     return ele;
 }
 
@@ -68,11 +73,15 @@ G1Element G1Element::FromByteVector(const std::vector<uint8_t>& bytevec)
     return G1Element::FromBytes(Bytes(bytevec));
 }
 
+G1Element G1Element::FromByteVectorUnchecked(const std::vector<uint8_t>& bytevec)
+{
+    return G1Element::FromBytesUnchecked(Bytes(bytevec));
+}
+
 G1Element G1Element::FromNative(const g1_t element)
 {
     G1Element ele;
     g1_copy(ele.p, element);
-    ele.CheckValid();
     return ele;
 }
 
@@ -203,7 +212,13 @@ G1Element operator*(const bn_t& k, const G1Element& a) { return a * k; }
 
 const size_t G2Element::SIZE;
 
-G2Element G2Element::FromBytes(const Bytes& bytes)
+G2Element G2Element::FromBytes(const Bytes& bytes) {
+    G2Element ele = G2Element::FromBytesUnchecked(bytes);
+    ele.CheckValid();
+    return ele;
+}
+
+G2Element G2Element::FromBytesUnchecked(const Bytes& bytes)
 {
     if (bytes.size() != SIZE) {
         throw std::invalid_argument("G2Element::FromBytes: Invalid size");
@@ -247,7 +262,6 @@ G2Element G2Element::FromBytes(const Bytes& bytes)
 
     g2_read_bin(ele.q, buffer, G2Element::SIZE + 1);
     BLS::CheckRelicErrors();
-    ele.CheckValid();
     return ele;
 }
 
@@ -256,11 +270,16 @@ G2Element G2Element::FromByteVector(const std::vector<uint8_t>& bytevec)
     return G2Element::FromBytes(Bytes(bytevec));
 }
 
+G2Element G2Element::FromByteVectorUnchecked(const std::vector<uint8_t>& bytevec)
+{
+    return G2Element::FromBytesUnchecked(Bytes(bytevec));
+}
+
+
 G2Element G2Element::FromNative(const g2_t element)
 {
     G2Element ele;
     g2_copy(ele.q, (g2_st*)element);
-    ele.CheckValid();
     return ele;
 }
 

--- a/src/elements.hpp
+++ b/src/elements.hpp
@@ -41,7 +41,9 @@ public:
     }
 
     static G1Element FromBytes(const Bytes& bytes);
+    static G1Element FromBytesUnchecked(const Bytes& bytes);
     static G1Element FromByteVector(const std::vector<uint8_t> &bytevec);
+    static G1Element FromByteVectorUnchecked(const std::vector<uint8_t> &bytevec);
     static G1Element FromNative(const g1_t element);
     static G1Element FromMessage(const std::vector<uint8_t> &message,
                                  const uint8_t *dst,
@@ -81,7 +83,9 @@ public:
     }
 
     static G2Element FromBytes(const Bytes& bytes);
+    static G2Element FromBytesUnchecked(const Bytes& bytes);
     static G2Element FromByteVector(const std::vector<uint8_t> &bytevec);
+    static G2Element FromByteVectorUnchecked(const std::vector<uint8_t> &bytevec);
     static G2Element FromNative(const g2_t element);
     static G2Element FromMessage(const std::vector<uint8_t>& message,
                                  const uint8_t* dst,

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -461,6 +461,8 @@ bool PopSchemeMPL::PopVerify(const G1Element &pubkey, const G2Element &signature
     g1_t g1s[2];
     g2_t g2s[2];
 
+    pubkey.CheckValid();
+    signature_proof.CheckValid();
     G1Element::Generator().Negate().ToNative(g1s[0]);
     pubkey.ToNative(g1s[1]);
     signature_proof.ToNative(g2s[0]);

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -107,8 +107,12 @@ bool CoreMPL::Verify(const G1Element& pubkey, const Bytes& message, const G2Elem
     std::vector<g2_st> vecG2(2);
 
     G1Element::Generator().Negate().ToNative(&vecG1[0]);
-    pubkey.CheckValid();
-    signature.CheckValid();
+    if (!pubkey.IsValid()) {
+        return false;
+    }
+    if (!signature.IsValid()) {
+        return false;
+    }
     pubkey.ToNative(&vecG1[1]);
     signature.ToNative(&vecG2[0]);
     hashedPoint.ToNative(&vecG2[1]);
@@ -199,11 +203,15 @@ bool CoreMPL::AggregateVerify(const vector<G1Element>& pubkeys,
     std::vector<g1_st> vecG1(nPubKeys + 1);
     std::vector<g2_st> vecG2(nPubKeys + 1);
     G1Element::Generator().Negate().ToNative(&vecG1[0]);
-    signature.CheckValid();
+    if (!signature.IsValid()) {
+        return false;
+    }
     signature.ToNative(&vecG2[0]);
 
     for (size_t i = 0; i < nPubKeys; ++i) {
-        pubkeys[i].CheckValid();
+        if (!pubkeys[i].IsValid()) {
+            return false;
+        }
         pubkeys[i].ToNative(&vecG1[i + 1]);
         G2Element::FromMessage(messages[i], (const uint8_t*)strCiphersuiteId.c_str(), strCiphersuiteId.length()).ToNative(&vecG2[i + 1]);
     }
@@ -461,8 +469,12 @@ bool PopSchemeMPL::PopVerify(const G1Element &pubkey, const G2Element &signature
     g1_t g1s[2];
     g2_t g2s[2];
 
-    pubkey.CheckValid();
-    signature_proof.CheckValid();
+    if (!pubkey.IsValid()) {
+        return false;
+    }
+    if (!signature_proof.IsValid()) {
+        return false;
+    }
     G1Element::Generator().Negate().ToNative(g1s[0]);
     pubkey.ToNative(g1s[1]);
     signature_proof.ToNative(g2s[0]);

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -107,6 +107,8 @@ bool CoreMPL::Verify(const G1Element& pubkey, const Bytes& message, const G2Elem
     std::vector<g2_st> vecG2(2);
 
     G1Element::Generator().Negate().ToNative(&vecG1[0]);
+    pubkey.CheckValid();
+    signature.CheckValid();
     pubkey.ToNative(&vecG1[1]);
     signature.ToNative(&vecG2[0]);
     hashedPoint.ToNative(&vecG2[1]);
@@ -197,9 +199,11 @@ bool CoreMPL::AggregateVerify(const vector<G1Element>& pubkeys,
     std::vector<g1_st> vecG1(nPubKeys + 1);
     std::vector<g2_st> vecG2(nPubKeys + 1);
     G1Element::Generator().Negate().ToNative(&vecG1[0]);
+    signature.CheckValid();
     signature.ToNative(&vecG2[0]);
 
     for (size_t i = 0; i < nPubKeys; ++i) {
+        pubkeys[i].CheckValid();
         pubkeys[i].ToNative(&vecG1[i + 1]);
         G2Element::FromMessage(messages[i], (const uint8_t*)strCiphersuiteId.c_str(), strCiphersuiteId.length()).ToNative(&vecG2[i + 1]);
     }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1183,6 +1183,61 @@ TEST_CASE("Schemes") {
     }
 }
 
+TEST_CASE("CheckValid")
+{
+    SECTION("Valid points should succeed") {
+        vector<uint8_t> seed(32, 0x05);
+        vector<uint8_t> msg1 = {10, 11, 12};
+
+        PrivateKey sk1 = BasicSchemeMPL().KeyGen(seed);
+        G1Element pk1 = BasicSchemeMPL().SkToG1(sk1);
+        pk1.CheckValid();
+
+        G2Element sig1 = AugSchemeMPL().Sign(sk1, msg1);
+        sig1.CheckValid();
+    }
+
+    SECTION("Invalid G1 points should not succeed")
+    {
+        string badPointHex =
+            "8d5d0fb73b9c92df4eab4216e48c3e358578b4cc30f82c268bd6fef3bd34b558628daf1afef798d4c3b0fcd8b28c8973";
+
+        // FromBytes throws
+        REQUIRE_THROWS(
+            G1Element::FromBytes(Bytes(Util::HexToBytes(badPointHex))));
+
+        // FromBytesUnchecked does not throw
+        G1Element pk =
+            G1Element::FromBytesUnchecked(Bytes(Util::HexToBytes(badPointHex)));
+        REQUIRE(pk.IsValid() == false);
+        REQUIRE_THROWS(pk.CheckValid());
+
+        vector<uint8_t> seed(32, 0x05);
+        vector<uint8_t> msg1 = {10, 11, 12};
+        PrivateKey sk1 = BasicSchemeMPL().KeyGen(seed);
+        G1Element pk1 = BasicSchemeMPL().SkToG1(sk1);
+        G2Element sig1 = AugSchemeMPL().Sign(sk1, msg1);
+        REQUIRE(AugSchemeMPL().Verify(pk, msg1, sig1) == false);
+    }
+
+    SECTION("Invalid G2 points should not succeed") {
+        g2_t point_native;
+        g2_set_infty(point_native);
+        fp2_rand(point_native->x);
+        fp2_rand(point_native->y);
+        fp2_rand(point_native->z);
+
+        G2Element point = G2Element::FromNative(point_native);
+        REQUIRE(point.IsValid() == false);
+        REQUIRE_THROWS(point.CheckValid());
+
+        auto badSer = point.Serialize();
+        std::cout <<Util::HexStr(badSer) << std::endl;
+
+        REQUIRE_THROWS(G2Element::FromByteVector(badSer));
+    }
+}
+
 int main(int argc, char* argv[])
 {
     int result = Catch::Session().run(argc, argv);


### PR DESCRIPTION
The validity check is now performed at signature validation time instead of element creation time. The from_bytes methods are still there, but they are no longer needed, due to the more efficient from_bytes_unchecked methods.

2000 pks parse time:
before: 0.5s
after: 0.09s
