### PR TITLE
Gt element unchecked

### DIFF
--- a/python-bindings/pythonbindings.cpp
+++ b/python-bindings/pythonbindings.cpp
@@ -676,6 +676,24 @@ PYBIND11_MODULE(blspy, m)
                 py::gil_scoped_release release;
                 return GTElement::FromBytes(data);
             })
+        .def(
+            "from_bytes_unchecked",
+            [](py::buffer const b) {
+                py::buffer_info info = b.request();
+                if (info.format != py::format_descriptor<uint8_t>::format() ||
+                    info.ndim != 1)
+                    throw std::runtime_error("Incompatible buffer format!");
+
+                if ((int)info.size != GTElement::SIZE) {
+                    throw std::invalid_argument(
+                        "Length of bytes object not equal to GTElement::SIZE");
+                }
+                auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
+                std::array<uint8_t, GTElement::SIZE> data;
+                std::copy(data_ptr, data_ptr + GTElement::SIZE, data.data());
+                py::gil_scoped_release release;
+                return GTElement::FromBytesUnchecked(data);
+            })
         .def("unity", &GTElement::Unity)
         .def(py::self == py::self)
         .def(py::self != py::self)

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -87,7 +87,7 @@ G1Element G1Element::FromMessage(const std::vector<uint8_t>& message,
     return FromMessage(Bytes(message), dst, dst_len);
 }
 
-G1Element G1Element::FromMessage(const Bytes& message,
+G1Element G1Element::FromMessage(Bytes const message,
                                  const uint8_t* dst,
                                  int dst_len)
 {
@@ -279,7 +279,7 @@ G2Element G2Element::FromMessage(const std::vector<uint8_t>& message,
     return FromMessage(Bytes(message), dst, dst_len);
 }
 
-G2Element G2Element::FromMessage(const Bytes& message,
+G2Element G2Element::FromMessage(Bytes const message,
                                  const uint8_t* dst,
                                  int dst_len)
 {
@@ -396,7 +396,7 @@ G2Element operator*(const bn_t& k, const G2Element& a) { return a * k; }
 
 const size_t GTElement::SIZE;
 
-GTElement GTElement::FromBytes(const Bytes& bytes)
+GTElement GTElement::FromBytes(Bytes const bytes)
 {
     if (bytes.size() != SIZE) {
         throw std::invalid_argument("GTElement::FromBytes: Invalid size");

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -398,13 +398,19 @@ const size_t GTElement::SIZE;
 
 GTElement GTElement::FromBytes(Bytes const bytes)
 {
+    GTElement ele = GTElement::FromBytesUnchecked(bytes);
+    if (gt_is_valid(*(gt_t*)&ele) == 0)
+        throw std::invalid_argument("GTElement is invalid");
+    return ele;
+}
+
+GTElement GTElement::FromBytesUnchecked(Bytes const bytes)
+{
     if (bytes.size() != SIZE) {
         throw std::invalid_argument("GTElement::FromBytes: Invalid size");
     }
     GTElement ele = GTElement();
     gt_read_bin(ele.r, bytes.begin(), GTElement::SIZE);
-    if (gt_is_valid(*(gt_t*)&ele) == 0)
-        throw std::invalid_argument("GTElement is invalid");
     BLS::CheckRelicErrors();
     return ele;
 }

--- a/src/elements.hpp
+++ b/src/elements.hpp
@@ -47,7 +47,7 @@ public:
     static G1Element FromMessage(const std::vector<uint8_t> &message,
                                  const uint8_t *dst,
                                  int dst_len);
-    static G1Element FromMessage(const Bytes& message,
+    static G1Element FromMessage(Bytes message,
                                  const uint8_t* dst,
                                  int dst_len);
     static G1Element Generator();
@@ -88,7 +88,7 @@ public:
     static G2Element FromMessage(const std::vector<uint8_t>& message,
                                  const uint8_t* dst,
                                  int dst_len);
-    static G2Element FromMessage(const Bytes& message,
+    static G2Element FromMessage(Bytes message,
                                  const uint8_t* dst,
                                  int dst_len);
     static G2Element Generator();
@@ -115,7 +115,7 @@ private:
 class GTElement {
 public:
     static const size_t SIZE = 384;
-    static GTElement FromBytes(const Bytes& bytes);
+    static GTElement FromBytes(Bytes bytes);
     static GTElement FromByteVector(const std::vector<uint8_t> &bytevec);
     static GTElement FromNative(const gt_t *element);
     static GTElement Unity();  // unity

--- a/src/elements.hpp
+++ b/src/elements.hpp
@@ -116,6 +116,7 @@ class GTElement {
 public:
     static const size_t SIZE = 384;
     static GTElement FromBytes(Bytes bytes);
+    static GTElement FromBytesUnchecked(Bytes bytes);
     static GTElement FromByteVector(const std::vector<uint8_t> &bytevec);
     static GTElement FromNative(const gt_t *element);
     static GTElement Unity();  // unity


### PR DESCRIPTION
We sometimes serialize and deserialize `GTElements` to pass them across process boundaries. Specifically, when the mempool validates a transaction, it does so in a separate process and receives the new BLS cache entries back from that process (in serialized form). Since we trust the other process (it's also part of the full node), we don't have to validate the `GTElement` when inserting it into the main BLS cache.

This overload adds symmetry with `G1Element.from_bytes_unchecked()` and `G2Element.from_bytes_unchecked()`