### PR TITLE
fix: add missing destructor for CoreMPL and `final` for nested classes

### DIFF
--- a/src/schemes.hpp
+++ b/src/schemes.hpp
@@ -39,6 +39,7 @@ class CoreMPL {
 public:
     CoreMPL() = delete;
     CoreMPL(const std::string& strId) : strCiphersuiteId(strId) {}
+    virtual ~CoreMPL() {}
     // Generates a private key from a seed, similar to HD key generation
     // (hashes the seed), and reduces it mod the group order
     virtual PrivateKey KeyGen(const vector<uint8_t>& seed);
@@ -96,7 +97,7 @@ protected:
     bool NativeVerify(g1_t *pubKeys, g2_t *mappedHashes, size_t length);
 };
 
-class BasicSchemeMPL : public CoreMPL {
+class BasicSchemeMPL final : public CoreMPL {
 public:
     static const std::string CIPHERSUITE_ID;
     BasicSchemeMPL() : CoreMPL(BasicSchemeMPL::CIPHERSUITE_ID) {}
@@ -117,7 +118,7 @@ public:
                          const G2Element& signature) override;
 };
 
-class AugSchemeMPL : public CoreMPL {
+class AugSchemeMPL final : public CoreMPL {
 
 public:
     static const std::string CIPHERSUITE_ID;
@@ -170,7 +171,7 @@ public:
                          const G2Element& signature) override;
 };
 
-class PopSchemeMPL : public CoreMPL {
+class PopSchemeMPL final : public CoreMPL {
 
 public:
     static const std::string CIPHERSUITE_ID;


### PR DESCRIPTION
There is no actual memory leak because no data in the the CoreMPL

But it resolves clang's warning:

    /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:95:2: warning: delete called on non-final 'bls::CoreMPL' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
            delete __ptr;
            ^
    /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:396:4: note: in instantiation of member function 'std::default_delete<bls::CoreMPL>::operator()' requested here
              get_deleter()(std::move(__ptr));
              ^
    main.cpp: note: in instantiation of member function 'std::unique_ptr<bls::CoreMPL>::~unique_ptr' requested here
    static const std::unique_ptr<bls::CoreMPL> pSchemeMLP{std::make_unique<bls::BasicSchemeMPL>()};