### PR TITLE
feat: implement memory-copy only of G1Element and G2Element

### DIFF
--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -80,6 +80,14 @@ G1Element G1Element::FromNative(const g1_t element)
     return ele;
 }
 
+G1Element G1Element::Copy() {
+    G1Element ele;
+    g1_copy(ele.p, this->p);
+
+    return ele;
+}
+
+
 G1Element G1Element::FromMessage(const std::vector<uint8_t>& message,
                                  const uint8_t* dst,
                                  int dst_len)
@@ -315,6 +323,13 @@ void G2Element::CheckValid() const {
 
 void G2Element::ToNative(g2_t output) const {
     g2_copy(output, (g2_st*)q);
+}
+
+G2Element G2Element::Copy() {
+    G2Element ele;
+    g2_copy(ele.q, this->q);
+
+    return ele;
 }
 
 G2Element G2Element::Negate() const

--- a/src/elements.hpp
+++ b/src/elements.hpp
@@ -59,6 +59,7 @@ public:
     GTElement Pair(const G2Element &b) const;
     uint32_t GetFingerprint() const;
     std::vector<uint8_t> Serialize() const;
+    G1Element Copy();
 
     friend bool operator==(const G1Element &a, const G1Element &b);
     friend bool operator!=(const G1Element &a, const G1Element &b);
@@ -99,6 +100,7 @@ public:
     G2Element Negate() const;
     GTElement Pair(const G1Element &a) const;
     std::vector<uint8_t> Serialize() const;
+    G2Element Copy();
 
     friend bool operator==(G2Element const &a, G2Element const &b);
     friend bool operator!=(G2Element const &a, G2Element const &b);


### PR DESCRIPTION
This implements a performant memory-only copy for G1Element and G2Element; I don't have benchmarks, but when we used this we saw significant performance improvements. 