### PR TITLE
fix python binding for from_message() on G1Element and G2Element

### DIFF
--- a/python-bindings/pythonbindings.cpp
+++ b/python-bindings/pythonbindings.cpp
@@ -418,7 +418,12 @@ PYBIND11_MODULE(blspy, m)
               return G1Element::FromBytesUnchecked({data_ptr, G1Element::SIZE});
             })
         .def("generator", &G1Element::Generator)
-        .def("from_message", py::overload_cast<const std::vector<uint8_t>&, const uint8_t*, int>(&G1Element::FromMessage), py::call_guard<py::gil_scoped_release>())
+        .def("from_message", [](std::string const msg, std::string const dst) {
+            py::gil_scoped_release release;
+            return G1Element::FromMessage(
+                std::vector<uint8_t>(msg.data(), msg.data() + msg.size()),
+                (uint8_t const*)dst.data(), dst.size());
+        })
         .def("pair", &G1Element::Pair, py::call_guard<py::gil_scoped_release>())
         .def("negate", &G1Element::Negate, py::call_guard<py::gil_scoped_release>())
         .def("get_fingerprint", &G1Element::GetFingerprint, py::call_guard<py::gil_scoped_release>())
@@ -560,7 +565,12 @@ PYBIND11_MODULE(blspy, m)
               return G2Element::FromBytesUnchecked({data_ptr, G2Element::SIZE});
             })
         .def("generator", &G2Element::Generator)
-        .def("from_message", py::overload_cast<const std::vector<uint8_t>&, const uint8_t*, int>(&G2Element::FromMessage), py::call_guard<py::gil_scoped_release>())
+        .def("from_message", [](std::string const msg, std::string const dst) {
+            py::gil_scoped_release release;
+            return G2Element::FromMessage(
+                std::vector<uint8_t>(msg.data(), msg.data() + msg.size()),
+                (uint8_t const*)dst.data(), dst.size());
+        })
         .def("pair", &G2Element::Pair, py::call_guard<py::gil_scoped_release>())
         .def("negate", &G2Element::Negate, py::call_guard<py::gil_scoped_release>())
         .def(

--- a/python-bindings/test.py
+++ b/python-bindings/test.py
@@ -41,6 +41,12 @@ def test_schemes():
     sk2 = BasicSchemeMPL.key_gen(seed)
     pk2 = sk2.get_g1()
 
+    g1 = G1Element.from_message(b"abcd", b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_")
+    assert bytes(g1) == bytes.fromhex("a5f756594a96c55f302360378568378dc19ea5eae3d5a88d77b8a30bb25c25ce24a85c6d7c851bcb1e34064fc0c79383")
+
+    g2 = G2Element.from_message(b"abcd", b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_")
+    assert g2 == AugSchemeMPL.g2_from_message(b"abcd")
+
     for Scheme in (BasicSchemeMPL, AugSchemeMPL, PopSchemeMPL):
         # Aggregate same message
         agg_pk = pk1 + pk2


### PR DESCRIPTION
the python binding for `G1Element.from_message()` and `G2Element.from_message()` don't work currently, and there's no test coverage for them.

This patch fixes them and adds test coverage.