### PR TITLE
Significantly speedup javascript bindings tasks by skipping libbls tests and benchmarks

### DIFF
--- a/emsdk_build.sh
+++ b/emsdk_build.sh
@@ -6,5 +6,5 @@ rm -rf js_build
 mkdir -p js_build
 cd js_build
 
-emcmake cmake -G "Unix Makefiles" ..
+emcmake cmake -G "Unix Makefiles" -DBUILD_BLS_TESTS=0 -DBUILD_BLS_BENCHMARKS=0 ..
 emmake make

--- a/js_build.sh
+++ b/js_build.sh
@@ -5,5 +5,5 @@ git submodule update --init --recursive
 mkdir js_build
 cd js_build
 
-cmake ../ -DCMAKE_TOOLCHAIN_FILE=$(dirname $(realpath $(which emcc)))/cmake/Modules/Platform/Emscripten.cmake
+cmake ../ -DBUILD_BLS_TESTS=0 -DBUILD_BLS_BENCHMARKS=0 -DCMAKE_TOOLCHAIN_FILE=$(dirname $(realpath $(which emcc)))/cmake/Modules/Platform/Emscripten.cmake
 cmake --build . --


### PR DESCRIPTION
Example `Build JS`:
* Before: ~4m 35s
* After: ~1m 38s

Example `Build and Test on ubuntu-latest CPython 3.11`:
* Before: ~4m 52s
* After: ~1m 57s