### PR TITLE
Use _add_or_double instead of just _add and pin BLST to specific revision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(SODIUM_DISABLE_TESTS "on" CACHE STRING "")
 set(SODIUM_CHIA_MINIMAL "on" CACHE STRING "")
 FetchContent_MakeAvailable(Sodium)
 
-set(BLST_GIT_TAG "origin/master")
+set(BLST_GIT_TAG "a8cd361c9f671577aeab3f074098443af92a53fc")
 set(BLST_REPOSITORY "https://github.com/supranational/blst")
 
 message(STATUS "blst will be built from: ${BLST_GIT_TAG} and repository ${BLST_REPOSITORY}")

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -193,14 +193,14 @@ std::ostream& operator<<(std::ostream& os, const G1Element& ele)
 
 G1Element& operator+=(G1Element& a, const G1Element& b)
 {
-    blst_p1_add(&(a.p), &(a.p), &(b.p));
+    blst_p1_add_or_double(&(a.p), &(a.p), &(b.p));
     return a;
 }
 
 G1Element operator+(const G1Element& a, const G1Element& b)
 {
     G1Element ans;
-    blst_p1_add(&(ans.p), &(a.p), &(b.p));
+    blst_p1_add_or_double(&(ans.p), &(a.p), &(b.p));
     return ans;
 }
 
@@ -360,14 +360,14 @@ std::ostream& operator<<(std::ostream& os, const G2Element& s)
 
 G2Element& operator+=(G2Element& a, const G2Element& b)
 {
-    blst_p2_add(&(a.q), &(a.q), &(b.q));
+    blst_p2_add_or_double(&(a.q), &(a.q), &(b.q));
     return a;
 }
 
 G2Element operator+(const G2Element& a, const G2Element& b)
 {
     G2Element ans;
-    blst_p2_add(&(ans.q), &(a.q), &(b.q));
+    blst_p2_add_or_double(&(ans.q), &(a.q), &(b.q));
     return ans;
 }
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -802,6 +802,21 @@ TEST_CASE("Signature tests")
             PopSchemeMPL().FastAggregateVerify(
                 pks_as_bytes, msg, aggSig.Serialize()) == false);
     }
+    SECTION("Aggregate same sig element")
+    {
+        vector<uint8_t> message = {100, 2, 254, 88, 90, 45, 23};
+
+        vector<uint8_t> seed(32, 0x50);
+
+        PrivateKey sk1 = BasicSchemeMPL().KeyGen(seed);
+
+        G1Element pk1 = sk1.GetG1Element();
+
+        G2Element sig1Aug = AugSchemeMPL().Sign(sk1, message);
+        G2Element aggSigAug = AugSchemeMPL().Aggregate({sig1Aug, sig1Aug});
+        REQUIRE(AugSchemeMPL().AggregateVerify(
+            {pk1, pk1}, vector<vector<uint8_t>>{message, message}, aggSigAug));
+    }
 }
 
 TEST_CASE("Agg sks")


### PR DESCRIPTION
Make sure to use`_add_or_double` rather than just `_add`. This properly supports creating an aggregated signature with the same sig.

Added test case that tests this functionality

Also, pin BLST to revision `a8cd361c9f671577aeab3f074098443af92a53fc` as very recent changes in `origin/master` cause some compilation issues.