### PR TITLE
Update CMakeLists.txt for blst `v0.3.11` release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,8 @@ FetchContent_MakeAvailable(Sodium)
 if (DEFINED ENV{BLST_MAIN})
   set(BLST_GIT_TAG "origin/master")
 else ()
-  # This is currently anchored to upstream 78fee18b25e16975e27b2d0314f6a323a23e6e83 dated 2023-08-22
-  set(BLST_GIT_TAG "78fee18b25e16975e27b2d0314f6a323a23e6e83")
+  # This is currently anchored to upstream 3dd0f804b1819e5d03fb22ca2e6fac105932043a dated 2023-08-09 v0.3.11
+  set(BLST_GIT_TAG "3dd0f804b1819e5d03fb22ca2e6fac105932043a")
 endif ()
 set(BLST_REPOSITORY "https://github.com/supranational/blst.git")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,8 @@ FetchContent_MakeAvailable(Sodium)
 if (DEFINED ENV{BLST_MAIN})
   set(BLST_GIT_TAG "origin/master")
 else ()
-  # This is currently anchored to upstream 5176127ee3b0f7a004c3f4bb9908684a8df75f8f dated 2023-06-30
-  set(BLST_GIT_TAG "5176127ee3b0f7a004c3f4bb9908684a8df75f8f")
+  # This is currently anchored to upstream 78fee18b25e16975e27b2d0314f6a323a23e6e83 dated 2023-08-22
+  set(BLST_GIT_TAG "78fee18b25e16975e27b2d0314f6a323a23e6e83")
 endif ()
 set(BLST_REPOSITORY "https://github.com/supranational/blst.git")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,8 @@ FetchContent_MakeAvailable(Sodium)
 if (DEFINED ENV{BLST_MAIN})
   set(BLST_GIT_TAG "origin/master")
 else ()
-  # This is currently anchored to upstream 6b837a0921cf41e501faaee1976a4035ae29d893 dated 2023-06-16
-  set(BLST_GIT_TAG "6b837a0921cf41e501faaee1976a4035ae29d893")
+  # This is currently anchored to upstream 5176127ee3b0f7a004c3f4bb9908684a8df75f8f dated 2023-06-30
+  set(BLST_GIT_TAG "5176127ee3b0f7a004c3f4bb9908684a8df75f8f")
 endif ()
 set(BLST_REPOSITORY "https://github.com/supranational/blst.git")
 


### PR DESCRIPTION
Update to BLST `v0.3.11` release commit.
Several fixes and some possible small speed improvement on ARM Macs compiled in portable mode per https://github.com/supranational/blst/issues/172