### PR TITLE
Update to cibuildwheel 2.11.2

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -157,7 +157,7 @@ jobs:
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: py.test -v {project}/python-bindings/test.py
       run:
-        pipx run --spec='cibuildwheel==2.9.0' cibuildwheel --output-dir dist 2>&1
+        pipx run --spec='cibuildwheel==2.11.2' cibuildwheel --output-dir dist 2>&1
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Consolidating wheels to cibuildwheel 2.11.2

This is the last version that uses bash in windows, which is needed for some scripts. The scripts could be edited to work in powershell, but this is left for another day