### PR TITLE
Use pyproject.toml instead of envvars for cibuildwheel

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -128,34 +128,10 @@ jobs:
     - name: Build and test
       env:
         CIBW_PRERELEASE_PYTHONS: True
-        CIBW_BUILD_VERBOSITY_MACOS: 0
-        CIBW_BUILD_VERBOSITY_LINUX: 0
-        CIBW_BUILD_VERBOSITY_WINDOWS: 0
         CIBW_BUILD: ${{ matrix.python.cibw-build }}
-        CIBW_SKIP: '*-manylinux_i686 *-win32 *-musllinux_*'
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux['arm'] }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.python.manylinux['intel'] }}
-        CIBW_ENVIRONMENT_LINUX: "PATH=/project/cmake-3.17.3-Linux-`uname -m`/bin:$PATH"
-        CIBW_BEFORE_ALL_LINUX: >
-          yum -y install epel-release
-          && echo "epel-release installed"
-          && yum -y install lzip
-          && echo "lzip installed"
-          && curl -L https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-`uname -m`.sh > cmake.sh
-          && yes | sh cmake.sh | cat
-          && rm -f /usr/bin/cmake
-          && cmake --version
-          && uname -a
-        CIBW_BEFORE_BUILD_LINUX: >
-          python -m pip install --upgrade pip
         CIBW_ARCHS_MACOS: ${{ matrix.os.cibw-archs-macos[matrix.arch.matrix] }}
-        CIBW_BEFORE_ALL_MACOS: >
-          brew install cmake
-        CIBW_BEFORE_BUILD_MACOS: >
-          python -m pip install --upgrade pip
-        CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.14"
-        CIBW_TEST_REQUIRES: pytest
-        CIBW_TEST_COMMAND: py.test -v {project}/python-bindings/test.py
       run:
         pipx run --spec='cibuildwheel==2.9.0' cibuildwheel --output-dir dist 2>&1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ before-build = "python -m pip install --upgrade pip"
 build-verbosity = ""
 before-all = "brew install cmake"
 before-build = "python -m pip install --upgrade pip"
-environment = "MACOSX_DEPLOYMENT_TARGET=11"
+environment = {MACOSX_DEPLOYMENT_TARGET="11", SYSTEM_VERSION_COMPAT=0}
 
 [tool.cibuildwheel.windows]
 build-verbosity = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,33 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+
+[tool.cibuildwheel]
+test-requires = "pytest"
+test-command = "py.test -v {project}/python-bindings/test.py"
+skip = "*-manylinux_i686 *-win32 *-musllinux_*"
+
+[tool.cibuildwheel.linux]
+build-verbosity = ""
+environment = {PATH="/project/cmake-3.17.3-Linux-`uname -m`/bin:$PATH"}
+before-all = [
+          "yum -y install epel-release",
+          "epel-release installed",
+          "yum -y install lzip",
+          "echo 'lzip installed'",
+          "curl -L https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-`uname -m`.sh > cmake.sh",
+          "yes | sh cmake.sh | cat",
+          "rm -f /usr/bin/cmake",
+          "cmake --version",
+          "uname -a"
+]
+before-build = "python -m pip install --upgrade pip"
+
+[tool.cibuildwheel.macos]
+build-verbosity = ""
+before-all = "brew install cmake"
+before-build = "python -m pip install --upgrade pip"
+environment = "MACOSX_DEPLOYMENT_TARGET=11"
+
+[tool.cibuildwheel.windows]
+build-verbosity = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ build-verbosity = ""
 environment = {PATH="/project/cmake-3.17.3-Linux-`uname -m`/bin:$PATH"}
 before-all = [
           "yum -y install epel-release",
-          "epel-release installed",
+          "echo epel-release installed",
           "yum -y install lzip",
           "echo 'lzip installed'",
           "curl -L https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-`uname -m`.sh > cmake.sh",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,18 +12,6 @@ skip = "*-manylinux_i686 *-win32 *-musllinux_*"
 
 [tool.cibuildwheel.linux]
 build-verbosity = ""
-environment = {PATH="/project/cmake-3.17.3-Linux-`uname -m`/bin:$PATH"}
-before-all = [
-          "yum -y install epel-release",
-          "echo epel-release installed",
-          "yum -y install lzip",
-          "echo 'lzip installed'",
-          "curl -L https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-`uname -m`.sh > cmake.sh",
-          "yes | sh cmake.sh | cat",
-          "rm -f /usr/bin/cmake",
-          "cmake --version",
-          "uname -a"
-]
 before-build = "python -m pip install --upgrade pip"
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
Puts most `cibuildwheel` configuration into `pyproject.toml` instead of using envvars in the github actions.

The rationale is that this makes it a little bit easier to build the wheel locally for debugging and testing as there is less configuration specific to GH actions

Note some of the envvars refer to GH action matrix items, so those remain in the GH workflow.