### PR TITLE
Update to pybind v2.11.1

### DIFF
--- a/python-bindings/CMakeLists.txt
+++ b/python-bindings/CMakeLists.txt
@@ -2,7 +2,7 @@
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11.git
-  GIT_TAG v2.10.0
+  GIT_TAG v2.11.1
 )
 FetchContent_MakeAvailable(pybind11)
 


### PR DESCRIPTION
Cmake is deprecating the way pybind finds the python interpreter. See https://cmake.org/cmake/help/latest/policy/CMP0148.html and https://github.com/pybind/pybind11/pull/4719