### PR TITLE
Division operator for GTElement (e1/e2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Implements BLS signatures with aggregation using [blst library](https://github.c
 for cryptographic primitives (pairings, EC, hashing) according to the
 [IETF BLS RFC](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bls-signature/)
 with [these curve parameters](https://datatracker.ietf.org/doc/draft-irtf-cfrg-pairing-friendly-curves/)
-for BLS12-381.
+for BLS12-381. The blst library has been [audited](https://medium.com/supranational/introducing-blst-2b6a988d68ee).
 
 Features:
 
 * Non-interactive signature aggregation following IETF specification
-* Works on Windows, Mac, Linux, BSD
+* Works on Windows, Mac, Linux, BSD, arm64, RISC-V
 * Efficient verification using Proof of Posssesion (only one pairing per distinct message)
 * Aggregate public keys and private keys
 * [EIP-2333](https://eips.ethereum.org/EIPS/eip-2333) key derivation (including unhardened BIP-32-like keys)
@@ -216,8 +216,8 @@ platforms in `.github/workflows/`.
 
 ## Discussion
 
-Discussion about this library and other Chia related development is in the #dev
-channel of Chia's [public Keybase channels](https://keybase.io/team/chia_network.public).
+Discussion about this library and other Chia related development is in the #chia-development
+channel of Chia's [Discord](https://discord.gg/chia).
 
 ## Code style
 
@@ -234,8 +234,8 @@ channel of Chia's [public Keybase channels](https://keybase.io/team/chia_network
 
 The primary build process for this repository is to use GitHub Actions to
 build binary wheels for MacOS, Linux (x64 and aarch64), and Windows and publish
-them with a source wheel on PyPi. MacOS ARM64 is supported but not automated
-due to a lack of M1 CI runners. See `.github/workflows/build.yml`. CMake uses
+them with a source wheel on PyPi. MacOS ARM64 is also supported.
+See `.github/workflows/build.yml`. CMake uses
 [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html)
 to download [pybind11](https://github.com/pybind/pybind11) for the Python
 bindings. Building
@@ -254,10 +254,7 @@ that chia-blockchain requires in it's main/release version in preparation
 for a new chia-blockchain release. Please branch or fork main and then create
 a pull request to the main branch. Linear merging is enforced on main and
 merging requires a completed review. PRs will kick off a GitHub actions ci
-build and analysis of bls-signatures at
-[lgtm.com](https://lgtm.com/projects/g/Chia-Network/bls-signatures/?mode=list).
-Please make sure your build is passing and that it does not increase alerts
-at lgtm.
+for building and testing.
 
 ## Specification and test vectors
 

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -474,6 +474,16 @@ GTElement operator*(GTElement& a, GTElement& b)
     return ans;
 }
 
+GTElement operator/(GTElement& a, GTElement& b)
+{
+    GTElement ans;
+    GTElement b_inv;
+    blst_fp12_inverse(&(b_inv.r), &(b.r));
+    blst_fp12_mul(&(ans.r), &(a.r), &(b_inv.r));
+    
+    return ans;
+}
+
 void GTElement::Serialize(uint8_t* buffer) const
 {
     memcpy(buffer, &r, GTElement::SIZE);

--- a/src/elements.hpp
+++ b/src/elements.hpp
@@ -130,6 +130,7 @@ public:
     friend bool operator!=(GTElement const &a, GTElement const &b);
     friend std::ostream &operator<<(std::ostream &os, const GTElement &s);
     friend GTElement operator*(GTElement &a, GTElement &b);
+    friend GTElement operator/(GTElement &a, GTElement &b);
 
 private:
     blst_fp12 r;

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1525,6 +1525,11 @@ TEST_CASE("GTElement")
         auto agg_sig_pair = G1Element::Generator().Pair(aggsig);
 
         REQUIRE(pair == agg_sig_pair);
+
+        // test division operator
+        GTElement gt1 = G1Element::Generator().Pair(G2Element::Generator());
+        GTElement gt2 = G1Element::Generator().Pair(G2Element::Generator());
+        REQUIRE(gt1 / gt2 == gt2 / gt1 );
     }
 }
 


### PR DESCRIPTION
Currently creating a [witness encryption scheme](https://github.com/kofi-dalvik/bls-witness-encryption) based on BLS signatures. I am using this library. However, I needed the GTElement class to support inversing through divisions. Instead of reimplementing element classes (since r is private in GT), this PR fixed the issue. 

I know BLS signature implementation does not use division, but libraries that depend on this might need it. Moreover, my witness encryption library currently depends on my fork, and I want to use the main Chia-Network/bls-signatures instead. 