### PR TITLE
Update blsjs.d.ts

### DIFF
--- a/js-bindings/blsjs.d.ts
+++ b/js-bindings/blsjs.d.ts
@@ -41,7 +41,7 @@ export declare class PopSchemeMPL {
 export declare class G1Element {
   static SIZE: number;
   static from_bytes(bytes: Uint8Array): G1Element;
-  static generator(): G2Element;
+  static generator(): G1Element;
   serialize(): Uint8Array;
   negate(): G1Element;
   deepcopy(): G1Element;


### PR DESCRIPTION
Updated blsjs.d.ts type inside the G1Element generator to return G1Element and not G2Element, or is this already correct ?